### PR TITLE
fix: correct post meta-data gaps

### DIFF
--- a/server/content/posts/personalised-art.html
+++ b/server/content/posts/personalised-art.html
@@ -3,6 +3,7 @@
 <!-- meta-data searchtitle: personalised-art  -->
 <!-- meta-data intro: Top tips for commisioning art -->
 <!-- meta-data author: mikemjharris  -->
+<!-- meta-data category: thoughts -->
 
 <p>
   A friend posted some pictures on twitter of an artistic impression of her playing computer games. I loved it, wanted something similar and a month later I was the proud owner of a piece of art depicting me sat on a deckchair with my computer.  The awesome banner you can see below is courtesy of the talented <a href="https://twitter.com/stephoodle" target="_blank">Steph</a>.

--- a/server/content/posts/waves-lighthouse.html
+++ b/server/content/posts/waves-lighthouse.html
@@ -3,7 +3,7 @@
 <!-- meta-data date:  09 Oct 2022 -->
 <!-- meta-data intro: Reading and studying Virginia Woolf in St Ives -->
 <!-- meta-data author: Mike Harris  -->
-<!-- meta-data category: throughts -->
+<!-- meta-data category: thoughts -->
 <!-- meta-data twitterimage: https://blog.mikemjharris.com/images/the-waves/artists-window-wide-small.jpg  -->
 <!-- meta-data twittercard: summary_large_image -->
 


### PR DESCRIPTION
Two small content fixes, found while adding search over the posts.

- `waves-lighthouse.html` had `category: throughts` — a typo, so it sat in a category of its own.
- `personalised-art.html` had no `category` at all, so it never appeared in any category listing. Set to `thoughts` (it's a post about commissioning art) — say if you'd rather it were `tech`.

No code changes.