### PR TITLE
chore: add prettier

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# Bulk reformats — ignore with:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# style: format with prettier
+eec7c5dffacf99c89af4b3442d1c4562f7822330

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
 
       - run: npm ci
 
+      - name: Check formatting
+        run: npm run format:check
+
       - name: Build assets
         run: npm run build
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,14 @@
+node_modules
+public/dist
+package-lock.json
+
+# Blog posts are hand-written HTML — reflowing them would rewrite the content.
+server/content
+
+# Prettier only parses .hbs with the Ember-specific glimmer parser, which mangles
+# plain Handlebars templates.
+*.hbs
+
+public/assets
+public/images
+public/media

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "printWidth": 100,
+  "trailingComma": "all"
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Blog             
+Blog
 ========================
 
 Base for my online blog - view it here [blog.mikemjharis.com](http://blog.mikemjharris.com) To run pull this repository then run the following commands.
@@ -11,6 +11,7 @@ Requires Node 24 (see `.nvmrc`).
 ```
 
 or for prod
+
 ```
     npm run build
     npm start
@@ -20,38 +21,37 @@ or for prod
 compiles the Sass, concatenates and minifies the client JS, precompiles the Handlebars
 templates and copies the browser libraries into `public/dist`.
 
+Posts are in the server/content folder. All the data such as title and date of published is inside meta tags at the top of each post. These are used to order the posts, put them in different cataegories etc.
 
-Posts are in the server/content folder.  All the data such as title and date of published is inside meta tags at the top of each post.  These are used to order the posts, put them in different cataegories etc.
-
-This project runs mainly using js technologies.  It has a bunch of funky css and svg animations - probably a few too many for a normal blog but I was playing around.
+This project runs mainly using js technologies. It has a bunch of funky css and svg animations - probably a few too many for a normal blog but I was playing around.
 
 Although using JS all through it also has server side rendering so can work without js in the browser.
 
-If you like the structure of the project feel free to use - it's a side project and probably not that stable but feel free to use as you wish.  If you find it helpful would be great to hear from you.
-
-
+If you like the structure of the project feel free to use - it's a side project and probably not that stable but feel free to use as you wish. If you find it helpful would be great to hear from you.
 
 Deployment
 ===========================
 
-The project runs in a docker container.  All you need as a dependency is docker.
+The project runs in a docker container. All you need as a dependency is docker.
 
-#### Build the docker file 
+#### Build the docker file
 
 ```
 docker build -t mikemjharris/blog .
 ```
 
 #### Running the project
+
 The project exposes port 8000 so map that to whichevere port you need.
+
 ```
 docker run -d -p 8000:8000 --name blog mikemjharris/blog
 ```
 
 Test
 ==========
+
 `npm test` or `npm run test:coverage`
 
 `npm run smoke` boots the server and checks it actually serves the pages, the built
 assets, the JSON API, the RSS feed and the MCP endpoint. CI runs this on every push.
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "jest": "^30.4.2",
         "jquery": "^4.0.0",
         "nodemon": "^3.1.14",
+        "prettier": "3.9.6",
         "sass": "^1.102.0"
       },
       "engines": {
@@ -7072,6 +7073,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "dev": "concurrently \"npm:dev:server\" \"npm:build:watch\"",
     "dev:server": "nodemon ./server/server.js -e html,js,hbs",
     "smoke": "node ./scripts/smoke.js",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "test": "jest",
     "test:coverage": "jest --coverage"
   },
@@ -32,6 +34,7 @@
     "jest": "^30.4.2",
     "jquery": "^4.0.0",
     "nodemon": "^3.1.14",
+    "prettier": "3.9.6",
     "sass": "^1.102.0"
   },
   "nodemonConfig": {

--- a/public/compile/service-worker.js
+++ b/public/compile/service-worker.js
@@ -1,52 +1,52 @@
-var cacheName = 'mikemjharris-blog-8bbb96b'
+var cacheName = 'mikemjharris-blog-8bbb96b';
 var filesToCache = [
-  "/",
-  "/api/posts",
-  "/dist/style.css",
-  "/jquery/dist/jquery.min.js",
-  "/handlebars/dist/handlebars.min.js",
-  "/dist/templates.js",
-  "/dist/main.js",
-  "https://fonts.googleapis.com/css?family=Spinnaker",
-  "https://fonts.googleapis.com/css?family=Inconsolata",
+  '/',
+  '/api/posts',
+  '/dist/style.css',
+  '/jquery/dist/jquery.min.js',
+  '/handlebars/dist/handlebars.min.js',
+  '/dist/templates.js',
+  '/dist/main.js',
+  'https://fonts.googleapis.com/css?family=Spinnaker',
+  'https://fonts.googleapis.com/css?family=Inconsolata',
 ];
 
-self.addEventListener('install', function(e) {
+self.addEventListener('install', function (e) {
   console.log('[ServiceWorker] Install');
   e.waitUntil(
-    caches.open(cacheName).then(function(cache) {
+    caches.open(cacheName).then(function (cache) {
       console.log('[ServiceWorker] Caching app shell');
       return cache.addAll(filesToCache);
-    })
+    }),
   );
 });
 
-self.addEventListener('activate', function(e) {
+self.addEventListener('activate', function (e) {
   console.log('[ServiceWorker] Activate');
   e.waitUntil(
-    caches.keys().then(function(keyList) {
-      return Promise.all(keyList.map(function(key) {
-        if (key !== cacheName) {
-          console.log('[ServiceWorker] Removing old cache', key);
-          return caches.delete(key);
-        }
-      }));
-    })
+    caches.keys().then(function (keyList) {
+      return Promise.all(
+        keyList.map(function (key) {
+          if (key !== cacheName) {
+            console.log('[ServiceWorker] Removing old cache', key);
+            return caches.delete(key);
+          }
+        }),
+      );
+    }),
   );
   return self.clients.claim();
 });
 
-self.addEventListener('fetch', function(event) {
+self.addEventListener('fetch', function (event) {
   event.respondWith(
-    caches.match(event.request)
-      .then(function(response) {
-        // Cache hit - return response
-        if (response) {
-          return response;
-        }
-
-        return fetch(event.request);
+    caches.match(event.request).then(function (response) {
+      // Cache hit - return response
+      if (response) {
+        return response;
       }
-    )
+
+      return fetch(event.request);
+    }),
   );
 });

--- a/public/javascripts/helpers.js
+++ b/public/javascripts/helpers.js
@@ -1,44 +1,43 @@
-(function() {
-    var register = function(Handlebars) {
-        var helpers = {
-            compare: function(lvalue, rvalue, options) {
-              if (arguments.length < 3) {
-                  throw new Error( 'Handlebars Helper equal needs 2 parameters' );
-                }
-              if ( lvalue !== rvalue ) {
-                  return options.inverse(this);
-              } else {
-                  return options.fn(this);
-              }
-            },
-            includes: function(lvalue, rvalue, options) {
-              if (arguments.length < 3) {
-                  throw new Error( 'Handlebars Helper equal needs 2 parameters' );
-                }
-              if ( lvalue.indexOf(rvalue) == -1) {
-                  return options.inverse(this);
-              } else {
-                  return options.fn(this);
-              }
-            },
-        };
-
-        if ( Handlebars && typeof Handlebars.registerHelper === 'function' ) {
-            for ( var prop in helpers ) {
-                Handlebars.registerHelper(prop, helpers[prop]);
-            }
-        } else {
-            // just return helpers object if we can't register helpers here
-            return helpers;
+(function () {
+  var register = function (Handlebars) {
+    var helpers = {
+      compare: function (lvalue, rvalue, options) {
+        if (arguments.length < 3) {
+          throw new Error('Handlebars Helper equal needs 2 parameters');
         }
+        if (lvalue !== rvalue) {
+          return options.inverse(this);
+        } else {
+          return options.fn(this);
+        }
+      },
+      includes: function (lvalue, rvalue, options) {
+        if (arguments.length < 3) {
+          throw new Error('Handlebars Helper equal needs 2 parameters');
+        }
+        if (lvalue.indexOf(rvalue) == -1) {
+          return options.inverse(this);
+        } else {
+          return options.fn(this);
+        }
+      },
     };
 
-    // client
-    if (typeof window !== 'undefined') {
-        register(Handlebars);
+    if (Handlebars && typeof Handlebars.registerHelper === 'function') {
+      for (var prop in helpers) {
+        Handlebars.registerHelper(prop, helpers[prop]);
+      }
     } else {
-        module.exports.register = register;
-        module.exports.helpers = register(null);
+      // just return helpers object if we can't register helpers here
+      return helpers;
     }
+  };
 
+  // client
+  if (typeof window !== 'undefined') {
+    register(Handlebars);
+  } else {
+    module.exports.register = register;
+    module.exports.helpers = register(null);
+  }
 })();

--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -1,41 +1,38 @@
 if ('serviceWorker' in navigator) {
-  navigator.serviceWorker
-           .register('/service-worker.js')
-           .then(function() { console.log('Service Worker Registered'); });
+  navigator.serviceWorker.register('/service-worker.js').then(function () {
+    console.log('Service Worker Registered');
+  });
 }
 
-(function ( $ ) {
-
-  $(function() {
+(function ($) {
+  $(function () {
     var posts;
 
     //initial call for posts
     $.ajax({
       url: '/api/posts',
       dataType: 'json',
-      success: function(data) {
+      success: function (data) {
         posts = data;
-      }
+      },
     });
 
     //browser history
-    if ( window.history && window.history.pushState ) {
-
-      $(window).on('popstate', function() {
+    if (window.history && window.history.pushState) {
+      $(window).on('popstate', function () {
         var _href = window.location.pathname;
         var pathParams = _href.match(/(?:\/(\w+))(?:\/([\w/-]+))?/);
 
         var path = pathParams[1];
         var id = pathParams[2];
 
-        if ( posts !== undefined ) {
-          if ( id !== undefined ) {
+        if (posts !== undefined) {
+          if (id !== undefined) {
             var post = findPost(id, posts);
             console.log(post);
             var html = MyApp.templates.post({ post: post });
             $('article').html(html);
-            window.location.href = window.location.href
-
+            window.location.href = window.location.href;
           } else {
             $('article').html('');
 
@@ -44,7 +41,7 @@ if ('serviceWorker' in navigator) {
             $('.active-menu').removeClass('active-menu');
 
             var menuNavs = $('nav a');
-            for ( var i = 0 ; i < menuNavs.length; i++){
+            for (var i = 0; i < menuNavs.length; i++) {
               if ($(menuNavs[i]).attr('href') === window.location.pathname) {
                 $(menuNavs[i]).closest('li').addClass('active-menu');
               }
@@ -54,10 +51,10 @@ if ('serviceWorker' in navigator) {
       });
     }
 
-    $('.menu').on('click' , toggleMenu);
+    $('.menu').on('click', toggleMenu);
 
-    $('body').on('click', '.posts', function(e) {
-      if( !$(this).data('navigate')) {
+    $('body').on('click', '.posts', function (e) {
+      if (!$(this).data('navigate')) {
         e.preventDefault();
         var _href = $(this).attr('href');
         window.history.pushState(null, null, _href);
@@ -71,22 +68,22 @@ if ('serviceWorker' in navigator) {
 
         var html = MyApp.templates['post']({ post: post });
         $('article').html('');
-        setTimeout(function() {
+        setTimeout(function () {
           $('article').append(html);
           // triggers code highlighting
           try {
             Prism.highlightAll();
-            console.log('aaa') 
-            window.location.href = window.location.href
+            console.log('aaa');
+            window.location.href = window.location.href;
           } catch (e) {
-            console.error(e)
+            console.error(e);
           }
-         }, 0);
+        }, 0);
       }
     });
 
-    $('.intro-animation ul li a').on('click', function(e) {
-      if ( !$(this).data('navigate') ) {
+    $('.intro-animation ul li a').on('click', function (e) {
+      if (!$(this).data('navigate')) {
         e.preventDefault();
         toggleMenu();
 
@@ -104,13 +101,13 @@ if ('serviceWorker' in navigator) {
         var newPage = _href.replace(/\//, '');
         $('article').html('');
         try {
-        // sometimew get errors with handlebars. Need to fix but for now just rely on server
-        // side rendering
+          // sometimew get errors with handlebars. Need to fix but for now just rely on server
+          // side rendering
           var html = MyApp.templates[newPage]({ posts: posts });
         } catch (e) {
           window.location = _href;
         }
-         setTimeout(function() {
+        setTimeout(function () {
           $('article').addClass('show');
           $('article').append(html);
           setTimeout(function () {
@@ -121,10 +118,10 @@ if ('serviceWorker' in navigator) {
     });
   });
 
-  function findPost( id, posts) {
+  function findPost(id, posts) {
     var foundPost;
-    posts.forEach(function ( post ) {
-      if (post.searchtitle === id ) {
+    posts.forEach(function (post) {
+      if (post.searchtitle === id) {
         foundPost = post;
       }
     });

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -9,13 +9,13 @@
     },
     {
       "src": "images/icons/icon-192.png",
-        "sizes": "192x192",
-        "type": "image/png"
+      "sizes": "192x192",
+      "type": "image/png"
     },
     {
       "src": "images/icons/icon-512.png",
-        "sizes": "512x512",
-        "type": "image/png"
+      "sizes": "512x512",
+      "type": "image/png"
     }
   ],
   "start_url": "/",

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,54 +1,55 @@
-var cacheName = 'mikemjharris-blog-d10bb8e'
+var cacheName = 'mikemjharris-blog-d10bb8e';
 var filesToCache = [
-  "/",
-  "/api/posts",
-  "/dist/style.css",
-  "/jquery/dist/jquery.min.js",
-  "/handlebars/dist/handlebars.min.js",
-  "/dist/templates.js",
-  "/dist/main.js",
-  "https://fonts.googleapis.com/css?family=Spinnaker",
-  "https://fonts.googleapis.com/css?family=Inconsolata",
-  "https://cdnjs.cloudflare.com/ajax/libs/prism/1.16.0/prism.min.js",
-  "https://cdnjs.cloudflare.com/ajax/libs/prism/1.16.0/themes/prism.min.css"
+  '/',
+  '/api/posts',
+  '/dist/style.css',
+  '/jquery/dist/jquery.min.js',
+  '/handlebars/dist/handlebars.min.js',
+  '/dist/templates.js',
+  '/dist/main.js',
+  'https://fonts.googleapis.com/css?family=Spinnaker',
+  'https://fonts.googleapis.com/css?family=Inconsolata',
+  'https://cdnjs.cloudflare.com/ajax/libs/prism/1.16.0/prism.min.js',
+  'https://cdnjs.cloudflare.com/ajax/libs/prism/1.16.0/themes/prism.min.css',
 ];
 
-self.addEventListener('install', function(e) {
+self.addEventListener('install', function (e) {
   console.log('[ServiceWorker] Install');
   e.waitUntil(
-    caches.open(cacheName).then(function(cache) {
+    caches.open(cacheName).then(function (cache) {
       console.log('[ServiceWorker] Caching app shell');
       return cache.addAll(filesToCache);
-    })
+    }),
   );
 });
 
-self.addEventListener('activate', function(e) {
+self.addEventListener('activate', function (e) {
   console.log('[ServiceWorker] Activate');
   e.waitUntil(
-    caches.keys().then(function(keyList) {
-      return Promise.all(keyList.map(function(key) {
-        if (key !== cacheName) {
-          console.log('[ServiceWorker] Removing old cache', key);
-          return caches.delete(key);
-        }
-      }));
-    })
+    caches.keys().then(function (keyList) {
+      return Promise.all(
+        keyList.map(function (key) {
+          if (key !== cacheName) {
+            console.log('[ServiceWorker] Removing old cache', key);
+            return caches.delete(key);
+          }
+        }),
+      );
+    }),
   );
   return self.clients.claim();
 });
 
-self.addEventListener('fetch', function(event) {
+self.addEventListener('fetch', function (event) {
   event.respondWith(
-    caches.open(cacheName).then(function(cache) {
-      return caches.match(event.request)
-      .then(function(response) {
-        var fetchPromise = fetch(event.request).then(function(networkResponse) {
+    caches.open(cacheName).then(function (cache) {
+      return caches.match(event.request).then(function (response) {
+        var fetchPromise = fetch(event.request).then(function (networkResponse) {
           cache.put(event.request, networkResponse.clone());
           return networkResponse;
-        })
+        });
         return response || fetchPromise;
-      })
-    })
+      });
+    }),
   );
 });

--- a/public/stylesheets/mobile.scss
+++ b/public/stylesheets/mobile.scss
@@ -1,7 +1,6 @@
 $body-font-size: 18px;
 
-@media screen and (max-width: 800px){
-
+@media screen and (max-width: 800px) {
   .desktop {
     display: none;
   }
@@ -15,15 +14,20 @@ $body-font-size: 18px;
   }
 
   .cross {
-     -webkit-animation: flash 0.4s ease-out;
+    -webkit-animation: flash 0.4s ease-out;
   }
 
   @-webkit-keyframes flash {
-    0% {background: none;}
-    20% {background: hsla(120, 30%, 60%, 1)}
-    100% {background: none}
+    0% {
+      background: none;
+    }
+    20% {
+      background: hsla(120, 30%, 60%, 1);
+    }
+    100% {
+      background: none;
+    }
   }
-
 
   .menu li {
     width: 40px;
@@ -34,7 +38,7 @@ $body-font-size: 18px;
 
   .cross li:nth-child(1) {
     transform-origin: 0% 50%;
-    transform: translateX(5px) rotate(45deg) ;
+    transform: translateX(5px) rotate(45deg);
   }
 
   .cross li:nth-child(2) {
@@ -42,21 +46,20 @@ $body-font-size: 18px;
   }
   .cross li:nth-child(3) {
     transform-origin: 0% 50%;
-    transform:  translateX(5px) rotate(-45deg)  ;
+    transform: translateX(5px) rotate(-45deg);
   }
 
-  .mobile{
+  .mobile {
     display: block;
   }
 
   header {
-
     ul {
       position: absolute;
       right: 0px;
       top: -10px;
       transform: translateZ(100px);
-      cursor:pointer;
+      cursor: pointer;
       padding: 15px;
     }
     li {
@@ -77,10 +80,9 @@ $body-font-size: 18px;
 
     #twitter-share {
       width: 90px;
-      padding-left: calc( 100% - 200px);
+      padding-left: calc(100% - 200px);
       text-align: right;
       svg {
-
         display: inline-block;
       }
     }
@@ -89,13 +91,13 @@ $body-font-size: 18px;
   h1 {
     font-size: 20px;
   }
-  h2, article h2 {
+  h2,
+  article h2 {
     font-size: $body-font-size * 1.3;
   }
   h3 {
     font-size: $body-font-size * 1;
   }
-
 
   main {
     flex-direction: column;
@@ -107,63 +109,61 @@ $body-font-size: 18px;
       background: white;
       width: 100%;
       header {
-       height: 45px;
-       width: 100%;
-      line-height: 20px;
+        height: 45px;
+        width: 100%;
+        line-height: 20px;
       }
       h1 {
         text-align: left;
         font-size: 20px;
-        width:100%;
+        width: 100%;
       }
     }
 
-      nav {
-        opacity: 0;
-        &.expand {
-          opacity: 1;
-        }
-        z-index: 1;
-        position: absolute;
-        right: 0px;
-        top: 50px;
-        width: 100%;
-        transform: translateY(-700px) scaleX(0.3) scaleY(4);;
-        transition: transform 0.5s cubic-bezier(.58,-1.06,.2,1.95);
-        background: transparent;
-        ul {
-          width: 100%;
-          -webkit-animation: none 1.5s linear;
-          li {
-
-            margin-left: auto;
-            margin-right: auto;
-            max-width: 300px;
-            width: 100%;
-            transition: all 0.5s;
-          }
-          .space {
-            display: none;
-          }
-          span {
-            display: none;
-            &.mobile {
-              cursor: pointer;
-              display:block;
-              background: red;
-              padding: 10px;
-            }
-          }
-        }
-
+    nav {
+      opacity: 0;
+      &.expand {
+        opacity: 1;
       }
-   }
+      z-index: 1;
+      position: absolute;
+      right: 0px;
+      top: 50px;
+      width: 100%;
+      transform: translateY(-700px) scaleX(0.3) scaleY(4);
+      transition: transform 0.5s cubic-bezier(0.58, -1.06, 0.2, 1.95);
+      background: transparent;
+      ul {
+        width: 100%;
+        -webkit-animation: none 1.5s linear;
+        li {
+          margin-left: auto;
+          margin-right: auto;
+          max-width: 300px;
+          width: 100%;
+          transition: all 0.5s;
+        }
+        .space {
+          display: none;
+        }
+        span {
+          display: none;
+          &.mobile {
+            cursor: pointer;
+            display: block;
+            background: red;
+            padding: 10px;
+          }
+        }
+      }
+    }
+  }
 
-   .intro-animation li:nth-child(n) {
+  .intro-animation li:nth-child(n) {
     -webkit-animation: none 1s linear;
-   }
+  }
 
-  nav>ul>li {
+  nav > ul > li {
     -webkit-animation: none 1.5s linear;
   }
   /* @-webkit-keyframes hide {
@@ -171,35 +171,40 @@ $body-font-size: 18px;
     to {opacity: 1; transform: translateY(--500px)}
    }*/
 
-   section {
+  section {
     height: calc(100vh - 55px);
     margin-top: 10px;
     padding: 0px;
-   }
+  }
 
   .expand {
     z-index: 2;
     transform: translateY(0px) translateZ(2px) scaleX(1) scaleY(1);
     height: 100%;
     -webkit-animation: expandback 0.6s linear;
-     background: hsla(0, 95%, 5%, 0.2);
-     li ul li {
-       box-shadow: 0px 5px 5px 3px #888888;
-     }
+    background: hsla(0, 95%, 5%, 0.2);
+    li ul li {
+      box-shadow: 0px 5px 5px 3px #888888;
+    }
   }
 
   @keyframes expandback {
-    0% { background: transparent; }
-    85% { background: transparent;}
-    110% { background: hsla(0, 95%, 5%, 0.2); }
+    0% {
+      background: transparent;
+    }
+    85% {
+      background: transparent;
+    }
+    110% {
+      background: hsla(0, 95%, 5%, 0.2);
+    }
   }
-
 
   #twitter-logo {
     display: none;
   }
 
-  article  {
+  article {
     padding: 20px;
     .content {
       margin-top: 10px;

--- a/public/stylesheets/reset.scss
+++ b/public/stylesheets/reset.scss
@@ -3,19 +3,87 @@
    License: none (public domain)
 */
 
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed, 
-figure, figcaption, footer, header, hgroup, 
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
   margin: 0;
   padding: 0;
   border: 0;
@@ -24,21 +92,34 @@ time, mark, audio, video {
   vertical-align: baseline;
 }
 /* HTML5 display-role reset for older browsers */
-article, aside, details, figcaption, figure, 
-footer, header, hgroup, menu, nav, section {
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
   display: block;
 }
 body {
   line-height: 1;
 }
-ol, ul {
+ol,
+ul {
   list-style: none;
 }
-blockquote, q {
+blockquote,
+q {
   quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
   content: '';
   content: none;
 }

--- a/public/stylesheets/style.scss
+++ b/public/stylesheets/style.scss
@@ -6,7 +6,7 @@
   font-family: spinnaker;
   font-display: swap;
   padding: 0px;
-  margin:0px;
+  margin: 0px;
   font-size: $body-font-size;
 }
 figcaption {
@@ -18,9 +18,13 @@ figcaption {
   }
 }
 em {
-  font-weight: bold; }
+  font-weight: bold;
+}
 
-h1, h2,h3, h4 {
+h1,
+h2,
+h3,
+h4 {
   font-weight: bold;
 }
 
@@ -49,7 +53,7 @@ div#loom-companion-mv3 {
 .quote {
   font-style: italic;
   font-weight: bold;
-  padding:  0 10px;
+  padding: 0 10px;
   &:before {
     content: '"';
     transform: translateY(-5px);
@@ -83,10 +87,10 @@ code {
 .highlight {
   padding: 15px;
   margin: 15px;
-  background: lighten($show-col ,10%);
+  background: lighten($show-col, 10%);
   transition: background 0.2s;
   &:hover {
-    background: lighten($show-col ,5%);
+    background: lighten($show-col, 5%);
   }
   h4 {
     display: flex;
@@ -145,10 +149,10 @@ article {
   min-width: 320px;
   width: 100%;
   line-height: 1.4;
-//  text-align: justify;
+  //  text-align: justify;
   overflow-scrolling: touch;
   height: 100%;
-  box-shadow:0px -10px 20px 10px white inset;
+  box-shadow: 0px -10px 20px 10px white inset;
   .break {
     margin: 75px;
     border-bottom: 1px solid $border-left-col;
@@ -188,10 +192,10 @@ article {
     li {
       margin: 5px 0;
     }
-
   }
 
-  ul.article li, p {
+  ul.article li,
+  p {
     margin-bottom: 1em;
     line-height: 2;
     a {
@@ -201,7 +205,7 @@ article {
       transition: all 0.2s;
       &:hover {
         background: $border-left-col;
-      };
+      }
     }
   }
 
@@ -217,7 +221,7 @@ article {
     background: white;
     max-width: calc(800px - 30px);
     min-width: 320px;
-    box-shadow:0px 10px 20px 10px white;
+    box-shadow: 0px 10px 20px 10px white;
     font-family: inconsolata;
   }
 
@@ -235,7 +239,8 @@ article {
       width: 100%;
       transition: background 0.2s;
 
-      &.space-content,  .space-content{
+      &.space-content,
+      .space-content {
         font-weight: bold;
         display: flex;
         justify-content: space-between;
@@ -244,7 +249,7 @@ article {
       }
 
       &:hover {
-        background: lighten( $show-col, 10%);
+        background: lighten($show-col, 10%);
       }
     }
     &:nth-child(odd) {
@@ -261,7 +266,7 @@ article {
     padding: 10px 5px;
     text-align: center;
   }
-  input[type="submit"] {
+  input[type='submit'] {
     padding: 10px;
     appearance: none;
     align-items: flex-start;
@@ -290,7 +295,8 @@ form {
     display: block;
   }
 
-  input , textarea{
+  input,
+  textarea {
     display: block;
     width: 100%;
     padding: 5px;
@@ -308,7 +314,7 @@ form {
   transition: all 0.2s;
   &:hover {
     background: $border-left-col;
-  };
+  }
 }
 
 #twitter {
@@ -317,14 +323,14 @@ form {
 
 #twitter-logo {
   position: fixed;
-  bottom:20px;
+  bottom: 20px;
   left: 10px;
   width: 150px;
   font-smoothing: antialiased;
   display: inline-block;
 }
 
-svg{
+svg {
   padding: 2px;
   width: 100%;
   li & {
@@ -349,19 +355,23 @@ svg{
   width: 110px;
   cursor: pointer;
   .bird path {
-   fill:#2aa9e0;
-   opacity: 0;
+    fill: #2aa9e0;
+    opacity: 0;
     transition: all 0.4s;
   }
   &:hover .bird path {
-    fill:#2aa9e0;
+    fill: #2aa9e0;
     opacity: 1;
   }
 }
 
 @keyframes dash {
-  from { stroke-dasharray: 0, 3000;}
-    to {stroke-dasharray: 3000, 1700;}
+  from {
+    stroke-dasharray: 0, 3000;
+  }
+  to {
+    stroke-dasharray: 3000, 1700;
+  }
 }
 
 .show h2 {
@@ -369,8 +379,14 @@ svg{
 }
 
 @keyframes showbackground {
-  from { background: none; box-shadow: 0px 0px 0px 0px white};
-  to {background: none; box-shadow: 0px 0px 0px 0px white};
+  from {
+    background: none;
+    box-shadow: 0px 0px 0px 0px white;
+  }
+  to {
+    background: none;
+    box-shadow: 0px 0px 0px 0px white;
+  }
 }
 
 a {
@@ -386,7 +402,7 @@ a {
 }
 
 .page {
-  display:none;
+  display: none;
 }
 .page.showpage {
   display: block;
@@ -394,8 +410,12 @@ a {
 }
 
 @keyframes showpage {
-  from {opacity: 0;}
-  to {opacity: 1;}
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 .show {
@@ -405,10 +425,23 @@ a {
 }
 
 @keyframes show {
-  0% { box-shadow: 0 0 0 0 white; opacity: 0;}
-  20% { box-shadow: 0 0 0 0 white; opacity: 0;}
-  21% { box-shadow: 0 0 5px 5px $show-col; opacity: 1; background: $show-col;}
-  100% { box-shadow: 0 0 0 0 white; opacity: 1;}
+  0% {
+    box-shadow: 0 0 0 0 white;
+    opacity: 0;
+  }
+  20% {
+    box-shadow: 0 0 0 0 white;
+    opacity: 0;
+  }
+  21% {
+    box-shadow: 0 0 5px 5px $show-col;
+    opacity: 1;
+    background: $show-col;
+  }
+  100% {
+    box-shadow: 0 0 0 0 white;
+    opacity: 1;
+  }
 }
 
 nav ul {
@@ -418,18 +451,22 @@ nav ul {
   position: relative;
   width: 200px;
   line-height: 20px;
-  animation: nav 0.7s cubic-bezier(0.2, 0.3, 0.4, 1.2 );
+  animation: nav 0.7s cubic-bezier(0.2, 0.3, 0.4, 1.2);
 }
 
-nav>ul>li {
+nav > ul > li {
   padding: 5px 0;
   margin: 0px;
-  animation: nav 0.7s cubic-bezier(0.2, 0.3, 0.4, 1.2 );
+  animation: nav 0.7s cubic-bezier(0.2, 0.3, 0.4, 1.2);
 }
 
 @keyframes nav {
-  0% {transform: translateY(1500px) ;}
-  100% {transform: translateY(0px) ;}
+  0% {
+    transform: translateY(1500px);
+  }
+  100% {
+    transform: translateY(0px);
+  }
 }
 
 .space {
@@ -481,17 +518,18 @@ ul li ul li {
 
 table {
   margin: 10px 0px;
-  border: 1px solid lighten($border-left-col,10%);
+  border: 1px solid lighten($border-left-col, 10%);
   thead {
     background: $border-left-col;
   }
-  td, th {
+  td,
+  th {
     padding: 5px;
     text-align: center;
   }
 }
 
-.active-menu  {
+.active-menu {
   animation: test2 2s linear;
   & .move {
     transform-origin: 100% 50%;
@@ -506,8 +544,6 @@ table {
   max-width: 100%;
   margin: 10px 0px;
 }
-
-
 
 .active-menu:hover {
   transform: translateX(0px) scaleX(1) scaleY(1);
@@ -532,60 +568,112 @@ audio:focus {
   height: 100%;
 }
 @keyframes test2 {
-  0% {transform: translateX(-4px) skewX(10deg); opacity: 1;}
-  1% {transform: translateX(-10px) skewX(20deg);}
-  7% {transform: translateX(4px) skewX(-10deg);}
-  17% {transform: translateX(-2px) skewX(5deg); }
-  27% {transform: translateX(2px) skewX(-5deg); }
-  37% {transform: translateX(0px) skewX(0deg);}
+  0% {
+    transform: translateX(-4px) skewX(10deg);
+    opacity: 1;
+  }
+  1% {
+    transform: translateX(-10px) skewX(20deg);
+  }
+  7% {
+    transform: translateX(4px) skewX(-10deg);
+  }
+  17% {
+    transform: translateX(-2px) skewX(5deg);
+  }
+  27% {
+    transform: translateX(2px) skewX(-5deg);
+  }
+  37% {
+    transform: translateX(0px) skewX(0deg);
+  }
 }
 
 @keyframes test {
-  0% {transform: translateX(-10px) skewX(10deg); opacity: 1;}
-  7% {transform: translateX(-20px) skewX(20deg);}
-  10% {transform: translateX(10px) skewX(-10deg);}
-  60% {transform: translateX(420px) skewX(-10deg); opacity:0.8;}
-  100% {transform: translateX(420px) scaleX(0.1) scaleY(4); opacity: 0.4;}
+  0% {
+    transform: translateX(-10px) skewX(10deg);
+    opacity: 1;
+  }
+  7% {
+    transform: translateX(-20px) skewX(20deg);
+  }
+  10% {
+    transform: translateX(10px) skewX(-10deg);
+  }
+  60% {
+    transform: translateX(420px) skewX(-10deg);
+    opacity: 0.8;
+  }
+  100% {
+    transform: translateX(420px) scaleX(0.1) scaleY(4);
+    opacity: 0.4;
+  }
 }
 
 @for $i from 1 through 20 {
   .intro-animation li:nth-child(#{$i + 0}) {
-    background: hsla( $i * 10 + 120, 60%, 80%,1);
+    background: hsla($i * 10 + 120, 60%, 80%, 1);
     animation: drop-#{$i} 2s linear;
     &.clear-back {
       background: white;
     }
-  };
+  }
 
   @keyframes drop-#{$i} {
-    0% {transform: translateY( #{$i * -50}px) scaleX(1) scaleY(1);}
-    9% {transform: translateY( #{$i * 50}px) scaleX(0.8) scaleY(1.2);}
-    27% {transform: translateY( #{$i * 150}px) scaleX(0.9) scaleY(1.1);}
-    36% {transform: translateY( #{$i * -30}px) scaleX(1) scaleY(1);}
-    45% {transform: translateY( #{$i * 55}px) scaleX(1) scaleY(1);}
-    54% {transform: translateY( #{$i * -10}px) scaleX(1) scaleY(1);}
-    64% {transform: translateY( #{$i * 20}px) scaleX(1) scaleY(1);}
-    73% {transform: translateY( #{$i * -5}px) scaleX(1) scaleY(1);}
-    82% {transform: translateY( #{$i * 5}px) scaleX(1) scaleY(1);}
-    91% {transform: translateY( #{$i * -2}px) scaleX(1) scaleY(1);}
-    100% {transform: translateY( 0px)  scaleX(1) scaleY(1);}
+    0% {
+      transform: translateY(#{$i * -50}px) scaleX(1) scaleY(1);
+    }
+    9% {
+      transform: translateY(#{$i * 50}px) scaleX(0.8) scaleY(1.2);
+    }
+    27% {
+      transform: translateY(#{$i * 150}px) scaleX(0.9) scaleY(1.1);
+    }
+    36% {
+      transform: translateY(#{$i * -30}px) scaleX(1) scaleY(1);
+    }
+    45% {
+      transform: translateY(#{$i * 55}px) scaleX(1) scaleY(1);
+    }
+    54% {
+      transform: translateY(#{$i * -10}px) scaleX(1) scaleY(1);
+    }
+    64% {
+      transform: translateY(#{$i * 20}px) scaleX(1) scaleY(1);
+    }
+    73% {
+      transform: translateY(#{$i * -5}px) scaleX(1) scaleY(1);
+    }
+    82% {
+      transform: translateY(#{$i * 5}px) scaleX(1) scaleY(1);
+    }
+    91% {
+      transform: translateY(#{$i * -2}px) scaleX(1) scaleY(1);
+    }
+    100% {
+      transform: translateY(0px) scaleX(1) scaleY(1);
+    }
   }
 }
 
 @for $i from 1 through 20 {
   li:nth-child(#{$i + 0}) {
     .smooth .intro-animation & {
-    animation: smooth-drop-#{$i} 0.9s cubic-bezier(0.815, 10.650, 0.555, -1.010);
+      animation: smooth-drop-#{$i} 0.9s cubic-bezier(0.815, 10.65, 0.555, -1.01);
     }
-  };
+  }
   li:nth-child(#{$i + 0}) {
     .smooth .intro-animation & {
-    animation: smooth-drop-#{$i} 0.9s cubic-bezier(0.815, 10.650, 0.555, -1.010);
+      animation: smooth-drop-#{$i} 0.9s cubic-bezier(0.815, 10.65, 0.555, -1.01);
     }
-  };
+  }
 
   @keyframes smooth-drop-#{$i} {
-    0% { transform: translateY(-100px)  scaleX(1.1) scaleY(0.8);}
-    #{100}% {transform: translateY(0px) scaleX(1) scaleY(1);}
+    0% {
+      transform: translateY(-100px) scaleX(1.1) scaleY(0.8);
+    }
+    #{100}% {
+      transform: translateY(0px) scaleX(1) scaleY(1);
+    }
   }
 }

--- a/public/stylesheets/variables.scss
+++ b/public/stylesheets/variables.scss
@@ -1,4 +1,4 @@
-$border-left-col: hsla(120, 60%,60%,1);
+$border-left-col: hsla(120, 60%, 60%, 1);
 $menu-move-col: hsla(240, 70%, 85%, 0.8);
 $show-col: hsla(300, 70%, 80%, 1);
 $body-font-size: 18px;

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -11,23 +11,17 @@ const vendorDist = path.join(dist, 'vendor');
 const stylesheets = [
   'public/stylesheets/reset.scss',
   'public/stylesheets/style.scss',
-  'public/stylesheets/mobile.scss'
+  'public/stylesheets/mobile.scss',
 ];
 
-const scripts = [
-  'public/javascripts/helpers.js',
-  'public/javascripts/main.js'
-];
+const scripts = ['public/javascripts/helpers.js', 'public/javascripts/main.js'];
 
 const templateDir = 'server/views/templates';
 const partialDir = 'server/views/templates/partials';
 
 // Browser copies of the two libraries the layout loads. Built into dist so the app
 // never has to serve node_modules over HTTP.
-const vendor = [
-  'jquery/dist/jquery.min.js',
-  'handlebars/dist/handlebars.min.js'
-];
+const vendor = ['jquery/dist/jquery.min.js', 'handlebars/dist/handlebars.min.js'];
 
 const read = (file) => fs.readFileSync(path.join(root, file), 'utf8');
 const write = (file, contents) => fs.writeFileSync(path.join(dist, file), contents);
@@ -36,7 +30,12 @@ const hbsFiles = (dir) =>
 
 const buildCss = () => {
   const css = stylesheets
-    .map((file) => sass.compile(path.join(root, file), { silenceDeprecations: ['import', 'global-builtin', 'color-functions'] }).css)
+    .map(
+      (file) =>
+        sass.compile(path.join(root, file), {
+          silenceDeprecations: ['import', 'global-builtin', 'color-functions'],
+        }).css,
+    )
     .join('\n');
   write('style.css', css);
 };
@@ -64,7 +63,7 @@ const buildTemplates = () => {
 
   const preamble = [
     'this["MyApp"] = this["MyApp"] || {};',
-    'this["MyApp"]["templates"] = this["MyApp"]["templates"] || {};'
+    'this["MyApp"]["templates"] = this["MyApp"]["templates"] || {};',
   ];
 
   write('templates.js', [...preamble, ...partials, ...templates].join('\n'));
@@ -75,7 +74,7 @@ const copyVendor = () => {
   vendor.forEach((file) => {
     fs.copyFileSync(
       path.join(root, 'node_modules', file),
-      path.join(vendorDist, path.basename(file))
+      path.join(vendorDist, path.basename(file)),
     );
   });
 };
@@ -92,7 +91,7 @@ const watch = () => {
   const targets = [
     ['public/stylesheets', buildCss],
     ['public/javascripts', buildJs],
-    [templateDir, buildTemplates]
+    [templateDir, buildTemplates],
   ];
 
   targets.forEach(([dir, rebuild]) => {

--- a/scripts/smoke.js
+++ b/scripts/smoke.js
@@ -13,7 +13,7 @@ const assets = [
   '/dist/main.js',
   '/dist/templates.js',
   '/dist/vendor/jquery.min.js',
-  '/dist/vendor/handlebars.min.js'
+  '/dist/vendor/handlebars.min.js',
 ];
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -95,9 +95,9 @@ const run = async () => {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Accept: 'application/json, text/event-stream'
+        Accept: 'application/json, text/event-stream',
       },
-      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' })
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
     });
     expectStatus(res, 200);
     if (!(await res.text()).includes('search_posts')) throw new Error('mcp tools not listed');
@@ -112,7 +112,7 @@ const run = async () => {
 const main = async () => {
   const server = spawn('node', [path.join(__dirname, '../server/server.js')], {
     env: { ...process.env, PORT: port },
-    stdio: ['ignore', 'pipe', 'inherit']
+    stdio: ['ignore', 'pipe', 'inherit'],
   });
 
   let output = '';
@@ -121,7 +121,9 @@ const main = async () => {
   });
 
   const exited = new Promise((resolve, reject) => {
-    server.on('exit', (code) => reject(new Error(`server exited early with code ${code}\n${output}`)));
+    server.on('exit', (code) =>
+      reject(new Error(`server exited early with code ${code}\n${output}`)),
+    );
     server.on('error', reject);
   });
 
@@ -133,7 +135,7 @@ const main = async () => {
   }
 
   checks.forEach(({ name, ok, error }) =>
-    console.log(`${ok ? 'ok  ' : 'FAIL'} ${name}${error ? ` — ${error}` : ''}`)
+    console.log(`${ok ? 'ok  ' : 'FAIL'} ${name}${error ? ` — ${error}` : ''}`),
   );
 
   const failed = checks.filter((c) => !c.ok);

--- a/server/helpers/post-search.js
+++ b/server/helpers/post-search.js
@@ -12,7 +12,7 @@ const ENTITIES = {
   '&nbsp;': ' ',
   '&mdash;': '—',
   '&ndash;': '–',
-  '&hellip;': '…'
+  '&hellip;': '…',
 };
 
 const absoluteUrl = (href) => (href.startsWith('/') ? BASE_URL + href : href);
@@ -34,7 +34,7 @@ const toPlainText = (html) => {
     .replace(/<!--[\s\S]*?-->/g, '')
     .replace(/<(script|style|iframe)[\s\S]*?<\/\1>/gi, '')
     .replace(/<a\s[^>]*href=["']([^"']*)["'][^>]*>([\s\S]*?)<\/a>/gi, (match, href, label) =>
-      inlineLink(label, href)
+      inlineLink(label, href),
     )
     .replace(/<(br|hr)\s*\/?>/gi, '\n')
     .replace(/<\/(p|div|h[1-6]|li|blockquote|pre|section)>/gi, '\n\n')
@@ -60,7 +60,7 @@ const summarise = (post) => ({
   category: normaliseCategory(post.category),
   tags: normaliseTags(post.tags),
   intro: post.intro,
-  url: postUrl(post)
+  url: postUrl(post),
 });
 
 const terms = (query) =>
@@ -126,8 +126,7 @@ const listPosts = (posts, { category, tag, since, limit = 20 } = {}) => {
     .map(summarise);
 };
 
-const findPost = (posts, searchtitle) =>
-  posts.find((post) => post.searchtitle === searchtitle);
+const findPost = (posts, searchtitle) => posts.find((post) => post.searchtitle === searchtitle);
 
 const categories = (posts) => {
   const counts = {};
@@ -149,5 +148,5 @@ module.exports = {
   searchPosts,
   listPosts,
   findPost,
-  categories
+  categories,
 };

--- a/server/helpers/source-content.js
+++ b/server/helpers/source-content.js
@@ -3,11 +3,11 @@ const fs = require('fs');
 const regex = /\<\!\-\-\smeta-data\s([A-z]+)\:\s(.+?(?=-->))/g;
 
 const getPostsFromPath = (path) => {
-  let posts = []
+  let posts = [];
   const files = fs.readdirSync(path);
   files.forEach((file) => {
     if (file.match(/.\.html$/)) {
-      let post ={ tags: []};
+      let post = { tags: [] };
       post.template = file;
       let data = fs.readFileSync(path + file);
       let str = data.toString('utf8');
@@ -15,33 +15,36 @@ const getPostsFromPath = (path) => {
 
       post.body = str;
       post.searchtitle = file;
-      while ( match = regex.exec(str) ) {
+      while ((match = regex.exec(str))) {
         if (match[1].trim() == 'tags') {
-          post[ match[ 1 ].trim() ] = match [ 2 ].trim().split(',');
-        } else if ( match[1].trim() == 'date') {
-          post[ match[ 1 ].trim() ] = new Date(match [ 2 ].trim()).toLocaleDateString('en-UK', {year: 'numeric', month: 'short', day: 'numeric'})
+          post[match[1].trim()] = match[2].trim().split(',');
+        } else if (match[1].trim() == 'date') {
+          post[match[1].trim()] = new Date(match[2].trim()).toLocaleDateString('en-UK', {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+          });
         } else {
-          post[ match[ 1 ].trim() ] = match [ 2 ].trim();
+          post[match[1].trim()] = match[2].trim();
         }
       }
       posts.push(post);
       posts = sortPosts(posts);
     }
-  })
+  });
   return posts;
-}
-
+};
 
 // helper functions
-const sortPosts = (posts) =>  {
+const sortPosts = (posts) => {
   return posts.sort((a, b) => {
     return new Date(b.date) - new Date(a.date);
   });
-}
+};
 
 const getPosts = () => {
   const postsPath = './server/content/posts/';
   return getPostsFromPath(postsPath);
-}
+};
 
-module.exports =  { getPosts, getPostsFromPath, sortPosts };
+module.exports = { getPosts, getPostsFromPath, sortPosts };

--- a/server/mcp/blog-mcp-server.js
+++ b/server/mcp/blog-mcp-server.js
@@ -9,7 +9,7 @@ const formatSummary = (post) =>
     `## ${post.title}`,
     `${post.date} · ${post.category}${post.tags.length ? ` · ${post.tags.join(', ')}` : ''}`,
     post.url,
-    post.intro || ''
+    post.intro || '',
   ]
     .filter(Boolean)
     .join('\n');
@@ -19,7 +19,7 @@ const formatPost = (post) =>
     `# ${post.title}`,
     `${post.date} · ${search.normaliseCategory(post.category)} · ${search.postUrl(post)}`,
     '',
-    search.toPlainText(post.body)
+    search.toPlainText(post.body),
   ].join('\n');
 
 // `posts` is the array the express app parses once at boot, so every tool is an in-memory read.
@@ -30,8 +30,8 @@ const createBlogMcpServer = (posts) => {
       instructions:
         "Read-only access to Mike Harris' blog at blog.mikemjharris.com - posts on tech, " +
         'keyboards, career changes, yearly retros and assorted side projects. Use search_posts to ' +
-        'find writing on a topic, then get_post to read one in full.'
-    }
+        'find writing on a topic, then get_post to read one in full.',
+    },
   );
 
   server.registerTool(
@@ -43,11 +43,14 @@ const createBlogMcpServer = (posts) => {
         'ranked by relevance. Returns summaries - use get_post to read one in full.',
       inputSchema: {
         query: z.string().describe('Search terms, e.g. "mechanical keyboard" or "docker deploy"'),
-        category: z.string().optional().describe('Restrict to a category, e.g. "tech" or "thoughts"'),
+        category: z
+          .string()
+          .optional()
+          .describe('Restrict to a category, e.g. "tech" or "thoughts"'),
         tag: z.string().optional().describe('Restrict to a single tag'),
-        limit: z.number().int().min(1).max(50).optional().describe('Max results (default 10)')
+        limit: z.number().int().min(1).max(50).optional().describe('Max results (default 10)'),
       },
-      annotations: { readOnlyHint: true, openWorldHint: false }
+      annotations: { readOnlyHint: true, openWorldHint: false },
     },
     async ({ query, category, tag, limit }) => {
       const results = search.searchPosts(posts, { query, category, tag, limit });
@@ -55,9 +58,9 @@ const createBlogMcpServer = (posts) => {
 
       return text(
         `Found ${results.length} post(s) matching "${query}":\n\n` +
-          results.map(formatSummary).join('\n\n')
+          results.map(formatSummary).join('\n\n'),
       );
-    }
+    },
   );
 
   server.registerTool(
@@ -70,19 +73,22 @@ const createBlogMcpServer = (posts) => {
       inputSchema: {
         category: z.string().optional().describe('Filter by category, e.g. "tech" or "thoughts"'),
         tag: z.string().optional().describe('Filter by tag'),
-        since: z.string().optional().describe('Only posts published on or after this date, e.g. "2024-01-01"'),
-        limit: z.number().int().min(1).max(100).optional().describe('Max results (default 20)')
+        since: z
+          .string()
+          .optional()
+          .describe('Only posts published on or after this date, e.g. "2024-01-01"'),
+        limit: z.number().int().min(1).max(100).optional().describe('Max results (default 20)'),
       },
-      annotations: { readOnlyHint: true, openWorldHint: false }
+      annotations: { readOnlyHint: true, openWorldHint: false },
     },
     async ({ category, tag, since, limit }) => {
       const results = search.listPosts(posts, { category, tag, since, limit });
       if (!results.length) return text('No posts matched those filters.');
 
       return text(
-        `${results.length} post(s), newest first:\n\n` + results.map(formatSummary).join('\n\n')
+        `${results.length} post(s), newest first:\n\n` + results.map(formatSummary).join('\n\n'),
       );
-    }
+    },
   );
 
   server.registerTool(
@@ -93,9 +99,9 @@ const createBlogMcpServer = (posts) => {
         'Read a single post in full as plain text. Takes the post slug (the "searchtitle" ' +
         'returned by search_posts, and the last segment of the post URL).',
       inputSchema: {
-        searchtitle: z.string().describe('Post slug, e.g. "three-key-keyboard"')
+        searchtitle: z.string().describe('Post slug, e.g. "three-key-keyboard"'),
       },
-      annotations: { readOnlyHint: true, openWorldHint: false }
+      annotations: { readOnlyHint: true, openWorldHint: false },
     },
     async ({ searchtitle }) => {
       const post = search.findPost(posts, searchtitle);
@@ -105,13 +111,13 @@ const createBlogMcpServer = (posts) => {
           content: [
             {
               type: 'text',
-              text: `No post with slug "${searchtitle}". Use search_posts or list_posts to find valid slugs.`
-            }
-          ]
+              text: `No post with slug "${searchtitle}". Use search_posts or list_posts to find valid slugs.`,
+            },
+          ],
         };
       }
       return text(formatPost(post));
-    }
+    },
   );
 
   server.registerTool(
@@ -120,7 +126,7 @@ const createBlogMcpServer = (posts) => {
       title: 'List categories',
       description: 'List the categories used across the blog, with a post count for each.',
       inputSchema: {},
-      annotations: { readOnlyHint: true, openWorldHint: false }
+      annotations: { readOnlyHint: true, openWorldHint: false },
     },
     async () => {
       const counts = search.categories(posts);
@@ -128,7 +134,7 @@ const createBlogMcpServer = (posts) => {
         .sort((a, b) => b[1] - a[1])
         .map(([category, count]) => `- ${category}: ${count} post(s)`);
       return text(`${posts.length} posts across ${lines.length} categories:\n${lines.join('\n')}`);
-    }
+    },
   );
 
   server.registerResource(
@@ -139,9 +145,9 @@ const createBlogMcpServer = (posts) => {
           uri: `blog://posts/${post.searchtitle}`,
           name: post.title,
           description: post.intro,
-          mimeType: 'text/plain'
-        }))
-      })
+          mimeType: 'text/plain',
+        })),
+      }),
     }),
     { title: 'Blog post', description: 'A single post as plain text', mimeType: 'text/plain' },
     async (uri, { searchtitle }) => {
@@ -149,7 +155,7 @@ const createBlogMcpServer = (posts) => {
       if (!post) throw new Error(`No post with slug "${searchtitle}"`);
 
       return { contents: [{ uri: uri.href, mimeType: 'text/plain', text: formatPost(post) }] };
-    }
+    },
   );
 
   return server;

--- a/server/mcp/route.js
+++ b/server/mcp/route.js
@@ -1,4 +1,6 @@
-const { StreamableHTTPServerTransport } = require('@modelcontextprotocol/sdk/server/streamableHttp.js');
+const {
+  StreamableHTTPServerTransport,
+} = require('@modelcontextprotocol/sdk/server/streamableHttp.js');
 const { createBlogMcpServer } = require('./blog-mcp-server');
 
 // Stateless: a fresh server and transport per request, so there is no session state to pin
@@ -6,15 +8,21 @@ const { createBlogMcpServer } = require('./blog-mcp-server');
 const methodNotAllowed = (res) =>
   res.status(405).json({
     jsonrpc: '2.0',
-    error: { code: -32000, message: 'Method not allowed. This MCP server is stateless - use POST.' },
-    id: null
+    error: {
+      code: -32000,
+      message: 'Method not allowed. This MCP server is stateless - use POST.',
+    },
+    id: null,
   });
 
 const mountMcp = (app, posts) => {
   app.use('/mcp', (req, res, next) => {
     res.header('Access-Control-Allow-Origin', '*');
     res.header('Access-Control-Allow-Methods', 'POST, OPTIONS');
-    res.header('Access-Control-Allow-Headers', 'Content-Type, mcp-session-id, mcp-protocol-version');
+    res.header(
+      'Access-Control-Allow-Headers',
+      'Content-Type, mcp-session-id, mcp-protocol-version',
+    );
     res.header('Access-Control-Expose-Headers', 'mcp-session-id, mcp-protocol-version');
     if (req.method === 'OPTIONS') return res.sendStatus(204);
     next();
@@ -38,7 +46,7 @@ const mountMcp = (app, posts) => {
         res.status(500).json({
           jsonrpc: '2.0',
           error: { code: -32603, message: 'Internal server error' },
-          id: null
+          id: null,
         });
       }
     }

--- a/server/routes/main.js
+++ b/server/routes/main.js
@@ -1,98 +1,97 @@
 const notFound = {
   title: '404',
-  intro: 'the page you were looking for wasn\'t found'
+  intro: "the page you were looking for wasn't found",
 };
 
-const xml2js = require("xml2js");
+const xml2js = require('xml2js');
 const { mountMcp } = require('../mcp/route');
 const date = new Date();
 
 module.exports = (app, posts) => {
-
   mountMcp(app, posts);
 
-  app.get('/', ( req, res ) => {
-    res.render('templates/home' , { posts: posts, latestPost: posts[ 0 ]  });
+  app.get('/', (req, res) => {
+    res.render('templates/home', { posts: posts, latestPost: posts[0] });
   });
 
-  app.get('/projects', ( req, res ) => {
-    res.render('templates/projects' , { posts: posts });
+  app.get('/projects', (req, res) => {
+    res.render('templates/projects', { posts: posts });
   });
 
-  app.get('/posts', ( req, res ) => {
-    res.render('templates/posts' , { posts: posts });
+  app.get('/posts', (req, res) => {
+    res.render('templates/posts', { posts: posts });
   });
 
-  app.get('/posts/top', ( req, res ) => {
-    res.render('templates/posts' , { posts: posts });
+  app.get('/posts/top', (req, res) => {
+    res.render('templates/posts', { posts: posts });
   });
 
-  app.get('/category', ( req, res ) => {
-    res.render('templates/category' , { posts: posts });
+  app.get('/category', (req, res) => {
+    res.render('templates/category', { posts: posts });
   });
 
-  app.get('/talks', ( req, res ) => {
-    res.render('templates/talks' , { posts: posts });
+  app.get('/talks', (req, res) => {
+    res.render('templates/talks', { posts: posts });
   });
 
-  app.get('/posts/:id', ( req, res ) => {
+  app.get('/posts/:id', (req, res) => {
     const postId = req.params.id;
     let postToShow = notFound;
 
-    posts.forEach(function ( post ) {
-      if ( post.searchtitle === postId ) {
+    posts.forEach(function (post) {
+      if (post.searchtitle === postId) {
         postToShow = post;
       }
     });
-    res.render('templates/post' , { post: postToShow });
+    res.render('templates/post', { post: postToShow });
   });
 
-  app.get('/contact', ( req, res ) => {
+  app.get('/contact', (req, res) => {
     res.render('templates/contact');
   });
 
-  app.get('/about', ( req, res ) => {
+  app.get('/about', (req, res) => {
     res.render('templates/about');
   });
 
   // API
-  app.get('/api/posts', ( req, res ) => {
+  app.get('/api/posts', (req, res) => {
     res.json(posts);
   });
 
-  app.get('/rss.xml', ( req, res ) => {
+  app.get('/rss.xml', (req, res) => {
     const rss = {
-    rss: {
-      $: {
-         "xmlns:atom":"http://www.w3.org/2005/Atom",
-         version:"2.0"
-      },
-      channel: {
+      rss: {
+        $: {
+          'xmlns:atom': 'http://www.w3.org/2005/Atom',
+          version: '2.0',
+        },
+        channel: {
           title: "MikeMJHarris' Blog",
-          link: "https://blog.mikemjharris.com/",
-          description: "Tech, some creative bits and other thoughts",
+          link: 'https://blog.mikemjharris.com/',
+          description: 'Tech, some creative bits and other thoughts',
           generator: "MikeMJHarris' custom generator",
-          language: "en-us",
+          language: 'en-us',
           lastBuildDate: date.toUTCString(),
-          "atom:link": {
+          'atom:link': {
             $: {
-                  href:"https://blog.mikemjharris.com/rss.xml",
-                  rel:"self",
-                  type:"application/rss+xml"
-               },
+              href: 'https://blog.mikemjharris.com/rss.xml',
+              rel: 'self',
+              type: 'application/rss+xml',
+            },
           },
           item: posts.map((post) => {
             return {
               title: post.title,
-              link: "https://blog.mikemjharris.com/posts/" + post.searchtitle,
+              link: 'https://blog.mikemjharris.com/posts/' + post.searchtitle,
               pubDate: post.date,
               guid: post.searchtitle,
-              description: post.body.replace(/href=\"\//g, "href=\"https://blog.mikemjharris.com/")
-            }
-          })
-        }
-      }
-    }
+              description: post.body.replace(/href=\"\//g, 'href="https://blog.mikemjharris.com/'),
+            };
+          }),
+        },
+      },
+    };
 
     const builder = new xml2js.Builder();
     const xml = builder.buildObject(rss);
@@ -100,5 +99,4 @@ module.exports = (app, posts) => {
     res.set('Content-Type', 'text/xml');
     res.send(xml);
   });
-
 };

--- a/server/server.js
+++ b/server/server.js
@@ -15,13 +15,16 @@ const posts = postHelpers.getPosts(postsPath);
 // view engine setup
 app.set('views', path.join(__dirname, 'views'));
 
-app.engine('.hbs', engine({
-  defaultLayout: 'main',
-  extname: '.hbs',
-  helpers: require('../public/javascripts/helpers.js').helpers, // same file that gets used on our client
-  layoutsDir: path.join(__dirname, 'views/layouts'),
-  partialsDir: path.join(__dirname, 'views/templates/partials')
-}));
+app.engine(
+  '.hbs',
+  engine({
+    defaultLayout: 'main',
+    extname: '.hbs',
+    helpers: require('../public/javascripts/helpers.js').helpers, // same file that gets used on our client
+    layoutsDir: path.join(__dirname, 'views/layouts'),
+    partialsDir: path.join(__dirname, 'views/templates/partials'),
+  }),
+);
 
 app.set('view engine', '.hbs');
 
@@ -39,7 +42,10 @@ app.get('/{*splat}', (req, res) => {
 
 app.use((err, req, res, next) => {
   console.error(err);
-  res.status(err.status || 500).type('text').send('Something went wrong');
+  res
+    .status(err.status || 500)
+    .type('text')
+    .send('Something went wrong');
 });
 
 app.set('port', process.env.PORT || 8000);

--- a/server/tests/helpers.test.js
+++ b/server/tests/helpers.test.js
@@ -1,30 +1,30 @@
 const postHelpers = require('../helpers/source-content');
 
 test('only gets html files from path', () => {
-    const posts = postHelpers.getPostsFromPath('./server/tests/fixtures/test-posts/');
-    expect(posts.length).toBe(1);
+  const posts = postHelpers.getPostsFromPath('./server/tests/fixtures/test-posts/');
+  expect(posts.length).toBe(1);
 });
 
 test('meta data is parsed correctly', () => {
-    const posts = postHelpers.getPostsFromPath('./server/tests/fixtures/test-posts/');
-    expect(posts[0].title).toEqual('Test post');
-    expect(posts[0].searchtitle).toEqual('test-post');
-    expect(posts[0].date).toEqual('24 Dec 2015');
-    expect(posts[0].intro).toEqual('Test post intro');
-    expect(posts[0].author).toEqual('Mike Harris');
-    expect(posts[0].category).toEqual('thoughts');
+  const posts = postHelpers.getPostsFromPath('./server/tests/fixtures/test-posts/');
+  expect(posts[0].title).toEqual('Test post');
+  expect(posts[0].searchtitle).toEqual('test-post');
+  expect(posts[0].date).toEqual('24 Dec 2015');
+  expect(posts[0].intro).toEqual('Test post intro');
+  expect(posts[0].author).toEqual('Mike Harris');
+  expect(posts[0].category).toEqual('thoughts');
 });
 
 test('sort posts sorts posts in correct order', () => {
-    const a = { date: new Date() };
-    const b = { date: new Date() + 5};
-    const posts = postHelpers.sortPosts([b, a]);
-    const postsBackwards = postHelpers.sortPosts([a, b]);
-    expect(posts).toEqual(postsBackwards);
+  const a = { date: new Date() };
+  const b = { date: new Date() + 5 };
+  const posts = postHelpers.sortPosts([b, a]);
+  const postsBackwards = postHelpers.sortPosts([a, b]);
+  expect(posts).toEqual(postsBackwards);
 });
 
 test('check getPosts returns production posts', () => {
-    const posts = postHelpers.getPosts();
-    // Test we get a bunch of posts back
-    expect(posts.length).toBeGreaterThan(20);
+  const posts = postHelpers.getPosts();
+  // Test we get a bunch of posts back
+  expect(posts.length).toBeGreaterThan(20);
 });

--- a/server/tests/post-search.test.js
+++ b/server/tests/post-search.test.js
@@ -7,7 +7,7 @@ const kelpPost = {
   category: 'tech',
   tags: ['kelp', ' seaweed '],
   intro: 'Growing kelp at Coral Bay',
-  body: '<!-- meta-data title: Farming Kelp --><p>Kelp grows fast in Coral Bay.</p>'
+  body: '<!-- meta-data title: Farming Kelp --><p>Kelp grows fast in Coral Bay.</p>',
 };
 
 const anemonePost = {
@@ -17,7 +17,7 @@ const anemonePost = {
   category: 'thoughts ',
   tags: [''],
   intro: 'On anemones',
-  body: '<p>An aside about kelp.</p>'
+  body: '<p>An aside about kelp.</p>',
 };
 
 const posts = [anemonePost, kelpPost];
@@ -34,13 +34,15 @@ describe('toPlainText', () => {
 
   test('keeps link destinations alongside their label', () => {
     const html = '<p>Bought a <a href="https://reef.example/kelp">kelp trimmer</a> today</p>';
-    expect(search.toPlainText(html)).toEqual('Bought a kelp trimmer (https://reef.example/kelp) today');
+    expect(search.toPlainText(html)).toEqual(
+      'Bought a kelp trimmer (https://reef.example/kelp) today',
+    );
   });
 
   test('makes relative links absolute', () => {
     const html = '<a href="/posts/tuna-turner">earlier post</a>';
     expect(search.toPlainText(html)).toEqual(
-      'earlier post (https://blog.mikemjharris.com/posts/tuna-turner)'
+      'earlier post (https://blog.mikemjharris.com/posts/tuna-turner)',
     );
   });
 
@@ -110,7 +112,7 @@ describe('production content', () => {
   test('every post has the meta-data the MCP tools depend on', () => {
     const realPosts = require('../helpers/source-content').getPosts();
     const incomplete = realPosts.filter(
-      (post) => !post.title || !post.searchtitle || !post.date || !post.category
+      (post) => !post.title || !post.searchtitle || !post.date || !post.category,
     );
     expect(incomplete.map((post) => post.template)).toEqual([]);
   });


### PR DESCRIPTION
Three commits, so the noisy one is easy to skip:

1. **`chore: add prettier`** — config, ignore file, npm scripts, CI step
2. **`style: format with prettier`** — the bulk reformat, 20 files
3. **`chore: ignore the prettier reformat in git blame`** — `.git-blame-ignore-revs`

## Config

Matched to the existing style so the reformat stays as small as possible: single quotes, 2-space indent, 100 char width, and trailing commas on multi-line lists only (per the house style — prettier never adds them to inline lists).

## What's ignored

- **`server/content`** — the blog posts are hand-written HTML and reflowing them would rewrite the content
- **`*.hbs`** — prettier only parses these with the Ember-specific glimmer parser, which mangles plain Handlebars
- `public/dist`, `package-lock.json`, and the asset/image/media dirs

## Verifying the reformat changed nothing

The Sass diff is the one that could have bitten — 234 changed lines in `style.scss` alone. I rebuilt before and after:

- `public/dist/main.js` (minified) — **byte-identical**
- `public/dist/templates.js` — **byte-identical**
- `public/dist/style.css` — **identical once whitespace is normalised**, same 562 rules. Prettier puts each selector in a list on its own line and sass carries that through, so the bytes differ but nothing else does.

Also checked `set-cache-name.sh`, which seds `public/service-worker.js` on deploy — prettier kept the single quotes, so the pattern still matches. Verified by running the sed.

21/21 unit tests and 17/17 smoke checks still pass.

## CI

`npm run format:check` runs before the build, so unformatted code fails the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)