### PR TITLE
chore: add lefthook to run the CI checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,21 @@ The project exposes port 8000 so map that to whichevere port you need.
 docker run -d -p 8000:8000 --name blog mikemjharris/blog
 ```
 
+Git hooks
+==========
+
+[lefthook](https://lefthook.dev) runs the same checks CI does, earlier. `npm install`
+installs the hooks via the `prepare` script; run `npx lefthook install` by hand if they
+ever go missing.
+
+| hook         | does                                                                            |
+| ------------ | ------------------------------------------------------------------------------- |
+| `pre-commit` | prettier on staged files (fixes and restages them), then `typecheck` and `test` |
+| `pre-push`   | `build` then `smoke`                                                            |
+
+Pass `--no-verify` to skip them for one command. CI runs the same checks regardless, so
+skipping locally only defers the failure.
+
 Test
 ==========
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,31 @@
+# Git hooks. Installed automatically by the `prepare` npm script; run
+# `npx lefthook install` by hand if the hooks ever go missing.
+#
+# Jobs run in order, not in parallel: format rewrites files and restages them, so
+# anything that reads those files has to run after it.
+
+pre-commit:
+  jobs:
+    - name: format
+      glob: '*.{ts,cts,mts,js,cjs,mjs,json,md,yml,yaml,scss,css,html}'
+      run: npx prettier --write --ignore-unknown {staged_files}
+      stage_fixed: true
+
+    - name: typecheck
+      glob: '*.{ts,cts,mts}'
+      run: npm run typecheck
+
+    # Plain `*.ts` rather than `server/**/*.ts` — a `**` glob does not match files
+    # sitting directly in the directory, which would silently skip server.ts.
+    - name: test
+      glob: '*.{ts,cts,mts}'
+      run: npm test
+
+# The slower checks, so a commit stays quick but nothing broken leaves the machine.
+pre-push:
+  jobs:
+    - name: build
+      run: npm run build
+
+    - name: smoke
+      run: npm run smoke

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "esbuild": "^0.28.2",
         "handlebars": "^4.7.9",
         "jquery": "^4.0.0",
+        "lefthook": "^2.1.10",
         "nodemon": "^3.1.14",
         "prettier": "3.9.6",
         "sass": "^1.102.0",
@@ -2664,6 +2665,169 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/lefthook": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/lefthook/-/lefthook-2.1.10.tgz",
+      "integrity": "sha512-K7mM4WoqMwqfXYK11EHy+lSH1uW8XHni3Yn/bSqyerPkUPygGdf3xn18JoV5HyA06xuQL3ofGAOjG01QX9oJ4w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "lefthook": "bin/index.js"
+      },
+      "optionalDependencies": {
+        "lefthook-darwin-arm64": "2.1.10",
+        "lefthook-darwin-x64": "2.1.10",
+        "lefthook-freebsd-arm64": "2.1.10",
+        "lefthook-freebsd-x64": "2.1.10",
+        "lefthook-linux-arm64": "2.1.10",
+        "lefthook-linux-x64": "2.1.10",
+        "lefthook-openbsd-arm64": "2.1.10",
+        "lefthook-openbsd-x64": "2.1.10",
+        "lefthook-windows-arm64": "2.1.10",
+        "lefthook-windows-x64": "2.1.10"
+      }
+    },
+    "node_modules/lefthook-darwin-arm64": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-2.1.10.tgz",
+      "integrity": "sha512-nw+X8wRNDoUUV6WSteyKBbcLySq+fsmZt5WV/s50ZJpysmsDKJOUMln6SllNfP+60dzUahAO7REco/2633BsLg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-darwin-x64": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-2.1.10.tgz",
+      "integrity": "sha512-KQ/bHmvpkFdHMn4pZnUdTf+GuSC+aBBgBTxZT4GW+6cSf+qbErKZBhK7cH6BmILsvx43+VzEArvHYY7YOfRFOQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-freebsd-arm64": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-2.1.10.tgz",
+      "integrity": "sha512-8su6DwydP7+pv7kG0zCtjphqsw4ouOnfexRUErapy5GTxYBoUOhYz3RSHTSWNRsK6W4jva7FPUh2Lp5/PSn30w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-freebsd-x64": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-2.1.10.tgz",
+      "integrity": "sha512-GeAJEFxko3Lk+AsnS3NleAFrpyMLFUKOlgJvPKuU0xHwVEI/z+ZoCcmuO0BX+4CS0NLbZhC/YQAvBASqDvvVdQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-linux-arm64": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-2.1.10.tgz",
+      "integrity": "sha512-1sHTCmpTWjVMs+yKPBLRNT1kuuIr1yjietlk7rCB6wFPVOS6Ph3o2zPFH2AvW1UymHlqwyHXzBr9EtDpQ7j1mQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-linux-x64": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-2.1.10.tgz",
+      "integrity": "sha512-z/VlRB3bh6mBvW3r1rwnJ5vP8z+Krx5gJzkZ4veDXh+6FlRTx8wtd3g3fllOv/yZMxkgmL3fQoFXv05Esa7vBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-openbsd-arm64": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-2.1.10.tgz",
+      "integrity": "sha512-430zL8sSIKw5P0YXGG6PB+eAhHa06n0PXuaERaAQE4Ss3odfqwnl5Mq9hQmkEnOS1EGiQEKkd0UHv/i4PtMNIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-openbsd-x64": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-x64/-/lefthook-openbsd-x64-2.1.10.tgz",
+      "integrity": "sha512-bgkO8PphGZVDhQgCJ524aYYPI5491pVmCiLPGjBIo1AvOSlIyw4N1Y+1C3QfqwEmechzw+Aq16SNc8pqv6UuXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-windows-arm64": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-2.1.10.tgz",
+      "integrity": "sha512-5Q6etF0Fla2DDA4ilDySrdNgiR5+W7cJZwnZ69Je3kvWCaWm4wnkuc8FEdjp3kiL2x3ZXipdI00f5vpO8aWmog==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/lefthook-windows-x64": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-2.1.10.tgz",
+      "integrity": "sha512-c/XH8YZtylG4XaxzqFfXluvq2LXq2W/p54Bnzn3+Z7E5X2Fk3JlFJAibulMbIt2+w8T7UI/r97ok5GqE4kGaeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "node": ">=24"
   },
   "scripts": {
+    "//prepare": "Installs the git hooks. Tolerates failure so `npm ci --omit=dev` and the Docker build, which have neither lefthook nor a .git dir, still succeed.",
+    "prepare": "lefthook install || true",
     "start": "node ./server/server.ts",
     "build": "node ./scripts/build.ts",
     "build:watch": "node ./scripts/build.ts --watch",
@@ -45,6 +47,7 @@
     "esbuild": "^0.28.2",
     "handlebars": "^4.7.9",
     "jquery": "^4.0.0",
+    "lefthook": "^2.1.10",
     "nodemon": "^3.1.14",
     "prettier": "3.9.6",
     "sass": "^1.102.0",


### PR DESCRIPTION
Runs the same checks CI does, earlier.

| hook | does |
| --- | --- |
| `pre-commit` | prettier over staged files (fixes and **restages** them), then `typecheck` and `test` |
| `pre-push` | `build` then `smoke` |

Split that way so a commit stays quick — pre-commit is ~2s, pre-push ~2s — while nothing broken leaves the machine. `--no-verify` skips them; CI runs the same checks regardless, so skipping only defers the failure.

Jobs run in order rather than in parallel, because `format` rewrites files and restages them, so anything reading those files has to come after it.

## Verified, not assumed

A hook that silently doesn't fire is worse than no hook, so I exercised each one:

- **Auto-format + restage** — committed a deliberately mangled `.ts`; prettier reformatted it and `git show HEAD:<file>` confirmed the *formatted* version is what landed in the commit, not the original.
- **Blocks a type error** — committing `(name: string): number => name` failed with exit code 1 and created no commit.
- **pre-push runs** — the push of this branch ran build + smoke (18/18) before uploading.
- **Docker still builds** — `prepare` now runs during `npm ci`, and the image has neither `.git` nor lefthook. `lefthook install || true` keeps it building; verified the image builds at the same 588MB and the container serves.

## One bug this turned up in my own config

The test job was first globbed `{server,scripts}/**/*.ts`. That looks right but a `**` glob does **not** match files sitting directly in the directory — so it silently skipped `server.ts`, `build.ts` and `smoke.ts`, i.e. most of the code. I only caught it because lefthook printed `test (skip) no matching staged files` on a file that should have matched. It's now plain `*.ts`.

## Note

This is the ESLint follow-up you asked about, redirected — ESLint is still parked. `typescript-eslint` caps at `typescript <6.1.0` (even on canary) and we're on 7.0.2, so adding it would have meant stepping TypeScript back a major. You chose to wait, so that stays a follow-up until typescript-eslint supports 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)