### PR TITLE
ci: let dependabot keep the dependencies current

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+
+updates:
+  # Minor and patch bumps arrive as one grouped PR a week. CI builds the assets, runs
+  # the tests, boots the server and boots the Docker image, so a green one is safe to
+  # merge on sight. Majors are deliberately left out of the group so each gets read.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: chore
+      include: scope
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      actions:
+        patterns:
+          - '*'
+    commit-message:
+      prefix: ci


### PR DESCRIPTION
No dependency update automation existed. `npm audit` is clean and nothing is outdated *today*, but the repo just came back from a 2018-era stack and nothing keeps it there.

Weekly, on Mondays:

- **npm** — minor and patch bumps **grouped into one PR**. CI builds assets, runs tests, boots the server and boots the Docker image, so a green grouped PR is safe to merge on sight.
- **github-actions** — grouped the same way.

**Majors are deliberately excluded from the group**, so each arrives on its own and gets read. That's not arbitrary: `cae2c71` in this repo is a revert of an unread dependabot major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)