### PR TITLE
fix: repair five broken internal links in posts

### DIFF
--- a/server/content/posts/2021-retro.html
+++ b/server/content/posts/2021-retro.html
@@ -110,7 +110,7 @@
 <h4>Cycling</h4>
 <p>
   So cycling was probably the big revelation this year. Early in the year I wrote about
-  <a href="/posts/pedalling-through-a-pandemic">pedalling through a pandemic</a> about the online
+  <a href="/posts/pedaling-through-a-pandemic">pedalling through a pandemic</a> about the online
   Zwift league I'd raced in over the winter. As hoped this translated to real world cycling - lots
   of rides with the neighbour opposite, other friends and colleagues. A highlight was a 100km
   <a href="https://www.strava.com/activities/5344132556">tour of the peak district</a> - again early

--- a/server/content/posts/2023-retro.html
+++ b/server/content/posts/2023-retro.html
@@ -101,7 +101,7 @@
 <h4>Story in the Stats</h4>
 <p>
   Yoga and running took center stage this year. After last years bad back one of
-  <a href="/posts/2022-retro.html">my 2022 resolutions</a> was to continue to physically look after
+  <a href="/posts/2022-retro">my 2022 resolutions</a> was to continue to physically look after
   myself. During the day that meant more movement and not getting stuck at the desk. When time
   allowed yoga kept everything nicely oiled and strong. When dips in attendance did occur I got back
   into the swing quicker than usual - nudged by the memory of sore backs and some tightness and

--- a/server/content/posts/adding-an-rss-feed.html
+++ b/server/content/posts/adding-an-rss-feed.html
@@ -9,7 +9,7 @@
 
 <p>
   A number of people who I respect on twitter are quite vocal that blogs should have an RSS feed.
-  I'm excited to announce, that as of this week, my blog too has an <a href="/rss.xm">RSS feed</a>!
+  I'm excited to announce, that as of this week, my blog too has an <a href="/rss.xml">RSS feed</a>!
   But what is an RSS feed, why do I need one and how did I add it to this project?
 </p>
 <h4>What is RSS?</h4>

--- a/server/content/posts/pedaling-through-a-pandemic.html
+++ b/server/content/posts/pedaling-through-a-pandemic.html
@@ -38,8 +38,8 @@
 <p>
   With the summer, warm weather and reduced restrictions the lure of the real world meant I only
   managed the odd ride. Most of my exercise time was spent running or
-  <a href="/posts/paddling-through-a-pandemic.html">paddling through a pandemic</a>. The main
-  cycling I did was just to pootle about town and avoid public transport.
+  <a href="/posts/paddling-through-a-pandemic">paddling through a pandemic</a>. The main cycling I
+  did was just to pootle about town and avoid public transport.
 </p>
 <h3>Dark cold nights of winter</h3>
 <p>

--- a/server/content/posts/working-at-wonderbly.html
+++ b/server/content/posts/working-at-wonderbly.html
@@ -90,7 +90,7 @@
   All that was left was to say good bye to the RA - enjoying celebratory drinks, some lovely leaving
   messages and one final glorious RA Christmas party. I'd negotiated a month off (thank you
   Wonderbly!) so was off to Bali to complete
-  <a href="/posts/all-yoga.htm">my yoga teacher training</a>.
+  <a href="/posts/all-yoga">my yoga teacher training</a>.
 </p>
 
 <h3>Starting a new job in 2020</h3>

--- a/server/tests/content-links.test.ts
+++ b/server/tests/content-links.test.ts
@@ -1,0 +1,95 @@
+// Every local link and asset reference in a post should resolve to something real.
+// A broken one is invisible in the browser because the catch-all route redirects
+// anything unmatched to the homepage, so it looks like it worked.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import express from 'express';
+import registerRoutes from '../routes/main.ts';
+import { getPosts } from '../helpers/source-content.ts';
+
+const POSTS_DIR = 'server/content/posts/';
+const PUBLIC_DIR = 'public';
+
+const posts = getPosts();
+const slugs = new Set(posts.map((post) => post.searchtitle));
+
+interface Ref {
+  file: string;
+  url: string;
+}
+
+/** Route paths the app actually registers, rather than a hardcoded list that would drift. */
+const registeredRoutes = (): Set<string> => {
+  const app = express();
+  registerRoutes(app, posts);
+  const stack = (app as unknown as { router: { stack: { route?: { path: string } }[] } }).router
+    .stack;
+  return new Set(stack.flatMap((layer) => (layer.route ? [layer.route.path] : [])));
+};
+
+/**
+ * Case-sensitive existence check. macOS would happily resolve `/images/Foo.png`
+ * against `foo.png`; the Linux box CI runs on would not.
+ */
+const fileExists = (relative: string): boolean => {
+  const full = path.join(PUBLIC_DIR, relative);
+  const dir = path.dirname(full);
+  if (!fs.existsSync(dir)) return false;
+  return fs.readdirSync(dir).includes(path.basename(full));
+};
+
+const localRefs = (): Ref[] => {
+  const refs: Ref[] = [];
+
+  for (const file of fs.readdirSync(POSTS_DIR)) {
+    if (!file.endsWith('.html')) continue;
+    const source = fs.readFileSync(POSTS_DIR + file, 'utf8');
+
+    for (const match of source.matchAll(/(?:src|href)=["']([^"']+)["']/g)) {
+      const raw = match[1];
+      if (!raw) continue;
+      // Skip absolute and protocol-relative URLs, anchors and mailto:.
+      if (!raw.startsWith('/') || raw.startsWith('//')) continue;
+      const url = raw.replace(/&amp;/g, '&').split(/[?#]/)[0];
+      if (url) refs.push({ file, url });
+    }
+  }
+
+  return refs;
+};
+
+test('every local reference in a post resolves to a file, a route or a real post', () => {
+  const routes = registeredRoutes();
+  const refs = localRefs();
+
+  // Guard against the matcher silently finding nothing and the test passing vacuously.
+  assert.ok(refs.length > 50, `expected plenty of local refs, found ${refs.length}`);
+
+  const broken = refs.filter(({ url }) => {
+    if (fileExists(url)) return false;
+    if (routes.has(url)) return false;
+    // `/posts/:id` is a real route, but the slug still has to exist.
+    const post = /^\/posts\/([^/]+)$/.exec(url);
+    if (post?.[1] && slugs.has(post[1])) return false;
+    return true;
+  });
+
+  assert.deepEqual(
+    broken.map(({ file, url }) => `${file} -> ${url}`),
+    [],
+  );
+});
+
+test('post links point at slugs rather than source filenames', () => {
+  // `/posts/adding-tags.html` would 302 to the homepage rather than 404, so it is
+  // worth calling out separately from a plain missing slug.
+  const filenameLinks = localRefs().filter(({ url }) => /^\/posts\/.+\.html$/.test(url));
+
+  assert.deepEqual(
+    filenameLinks.map(({ file, url }) => `${file} -> ${url}`),
+    [],
+  );
+});


### PR DESCRIPTION
Started as the one broken link I mentioned. Writing the test found four more.

| post | link | should be |
| --- | --- | --- |
| `adding-an-rss-feed` | `/rss.xm` | `/rss.xml` |
| `2021-retro` | `/posts/pedalling-through-a-pandemic` | `pedaling` — one `l` |
| `2023-retro` | `/posts/2022-retro.html` | `/posts/2022-retro` — slug, not filename |
| `pedaling-through-a-pandemic` | `/posts/paddling-through-a-pandemic.html` | slug, not filename |
| `working-at-wonderbly` | `/posts/all-yoga.htm` | `/posts/all-yoga` — missing `l` |

**Every one of them silently 302'd to the homepage** rather than 404ing, thanks to the catch-all route — so they looked like they worked. The RSS one is, pleasingly, in the post announcing the RSS feed.

All five verified to return 200 against the running server after the fix.

## The test

Walks every local `href` and `src` across all 76 posts and asserts each resolves to one of:

- a file under `public/`
- a route the app **actually registers**
- a real post slug

Two details that make it stronger than the throwaway script I first used:

- **Routes are read off the express router**, not hardcoded — so deleting a route fails any post still linking to it, instead of the list quietly drifting.
- **The file check reads the directory rather than calling `existsSync`.** macOS would happily resolve `/images/Foo.png` against `foo.png`; the Linux box CI runs on would not, so an `existsSync` version would pass locally and fail in CI.

There's also a guard asserting it found more than 50 refs, so the test can't pass vacuously if the matcher ever stops matching. A second test specifically catches `/posts/<file>.html` links, since those are a distinct mistake from a missing slug.

24 tests now, up from 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)