### PR TITLE
test: cover the MCP server, and stop smoke picking a fixed port

### DIFF
--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -1,9 +1,30 @@
 // Boots the real server and checks it serves the pages, the built assets and the
 // MCP endpoint. Run in CI so a broken boot fails the build rather than the deploy.
 import { spawn } from 'node:child_process';
+import { createServer } from 'node:net';
 import path from 'node:path';
 
-const port = process.env.SMOKE_PORT ?? '8123';
+/**
+ * Ask the OS for a spare port rather than hardcoding one. A fixed port makes this
+ * fail spuriously whenever anything else is already listening — including a previous
+ * run of this script that has not fully released it yet.
+ */
+const freePort = (): Promise<number> =>
+  new Promise((resolve, reject) => {
+    const probe = createServer();
+    probe.on('error', reject);
+    probe.listen(0, () => {
+      const address = probe.address();
+      if (address === null || typeof address === 'string') {
+        probe.close(() => reject(new Error('could not determine a free port')));
+        return;
+      }
+      const { port } = address;
+      probe.close(() => resolve(port));
+    });
+  });
+
+const port = process.env.SMOKE_PORT ?? String(await freePort());
 const base = `http://localhost:${port}`;
 const bootTimeoutMs = 30000;
 
@@ -107,17 +128,36 @@ const run = async (): Promise<void> => {
     if (!xml.includes('<rss') || !xml.includes('<item>')) throw new Error('not an rss feed');
   });
 
-  await check('POST /mcp lists tools', async () => {
-    const res = await get(`${base}/mcp`, {
+  const mcp = (body: unknown): Promise<Response> =>
+    get(`${base}/mcp`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Accept: 'application/json, text/event-stream',
       },
-      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+      body: JSON.stringify(body),
     });
+
+  await check('POST /mcp lists tools', async () => {
+    const res = await mcp({ jsonrpc: '2.0', id: 1, method: 'tools/list' });
     expectStatus(res, 200);
     if (!(await res.text()).includes('search_posts')) throw new Error('mcp tools not listed');
+  });
+
+  // Listing tools only proves the server mounted. Call one so the whole path —
+  // parse the posts, search them, format the reply — is exercised over HTTP.
+  await check('POST /mcp runs a tool against real posts', async () => {
+    const res = await mcp({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name: 'search_posts', arguments: { query: 'keyboard', limit: 3 } },
+    });
+    expectStatus(res, 200);
+    const body = await res.text();
+    if (body.includes('"isError":true'))
+      throw new Error(`tool call errored: ${body.slice(0, 200)}`);
+    if (!/Found \d+ post\(s\)/.test(body)) throw new Error('tool returned no search results');
   });
 
   await check('node_modules is not served', async () => {

--- a/server/tests/blog-mcp-server.test.ts
+++ b/server/tests/blog-mcp-server.test.ts
@@ -1,0 +1,219 @@
+// Drives the MCP server through a real client over an in-memory transport, so the
+// tools are exercised the way an agent would call them rather than by poking at
+// internals. The HTTP layer is covered separately by the smoke test.
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createBlogMcpServer, formatPost, formatSummary } from '../mcp/blog-mcp-server.ts';
+import { summarise } from '../helpers/post-search.ts';
+import type { Post } from '../helpers/source-content.ts';
+
+const kelpPost: Post = {
+  template: 'farming-kelp.html',
+  title: 'Farming Kelp',
+  searchtitle: 'farming-kelp',
+  date: '4 May 2021',
+  category: 'tech',
+  tags: ['kelp', 'seaweed'],
+  intro: 'Growing kelp at Coral Bay',
+  body: '<!-- meta-data title: Farming Kelp --><p>Kelp grows fast in Coral Bay.</p>',
+};
+
+const anemonePost: Post = {
+  template: 'anemone-notes.html',
+  title: 'Anemone Notes',
+  searchtitle: 'anemone-notes',
+  date: '7 Jun 2022',
+  category: 'thoughts',
+  tags: [],
+  intro: 'On anemones',
+  body: '<p>An aside about kelp.</p>',
+};
+
+const posts = [anemonePost, kelpPost];
+
+const connect = async (): Promise<Client> => {
+  const server = createBlogMcpServer(posts);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+  return client;
+};
+
+type ToolResult = Awaited<ReturnType<Client['callTool']>>;
+
+/**
+ * callTool's result is a union that still includes the legacy `toolResult` shape,
+ * and content itself is a union of text/image/resource parts. The blog only ever
+ * returns text, so narrow to that and fail loudly if it ever does not.
+ */
+const textOf = (result: ToolResult): string => {
+  const content = 'content' in result ? result.content : undefined;
+  assert.ok(Array.isArray(content), 'expected a content array');
+  return content
+    .map((part) => (typeof part === 'object' && part && 'text' in part ? String(part.text) : ''))
+    .join('\n');
+};
+
+describe('tool registration', () => {
+  test('exposes exactly the four blog tools', async () => {
+    const client = await connect();
+    const { tools } = await client.listTools();
+    assert.deepEqual(tools.map((tool) => tool.name).sort(), [
+      'get_post',
+      'list_categories',
+      'list_posts',
+      'search_posts',
+    ]);
+  });
+
+  test('every tool is marked read-only so agents know it is safe', async () => {
+    const client = await connect();
+    const { tools } = await client.listTools();
+    for (const tool of tools) {
+      assert.equal(tool.annotations?.readOnlyHint, true, `${tool.name} is not read-only`);
+    }
+  });
+});
+
+describe('search_posts', () => {
+  test('ranks a title match above a passing body mention', async () => {
+    const client = await connect();
+    const result = await client.callTool({ name: 'search_posts', arguments: { query: 'kelp' } });
+    const text = textOf(result);
+    assert.match(text, /Found 2 post\(s\)/);
+    assert.ok(
+      text.indexOf('Farming Kelp') < text.indexOf('Anemone Notes'),
+      'title match should rank first',
+    );
+  });
+
+  test('says so rather than erroring when nothing matches', async () => {
+    const client = await connect();
+    const result = await client.callTool({ name: 'search_posts', arguments: { query: 'dolphin' } });
+    assert.match(textOf(result), /No posts found matching "dolphin"/);
+    assert.notEqual(result.isError, true);
+  });
+
+  test('honours the limit', async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      name: 'search_posts',
+      arguments: { query: 'kelp', limit: 1 },
+    });
+    assert.match(textOf(result), /Found 1 post\(s\)/);
+  });
+
+  test('rejects a limit outside the schema range', async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      name: 'search_posts',
+      arguments: { query: 'kelp', limit: 999 },
+    });
+    assert.equal(result.isError, true);
+  });
+});
+
+describe('list_posts', () => {
+  test('filters by category', async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      name: 'list_posts',
+      arguments: { category: 'thoughts' },
+    });
+    const text = textOf(result);
+    assert.match(text, /Anemone Notes/);
+    assert.doesNotMatch(text, /Farming Kelp/);
+  });
+
+  test('since excludes older posts', async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      name: 'list_posts',
+      arguments: { since: '1 Jan 2022' },
+    });
+    const text = textOf(result);
+    assert.match(text, /Anemone Notes/);
+    assert.doesNotMatch(text, /Farming Kelp/);
+  });
+
+  test('reports an empty result rather than an error', async () => {
+    const client = await connect();
+    const result = await client.callTool({ name: 'list_posts', arguments: { tag: 'dolphin' } });
+    assert.match(textOf(result), /No posts matched those filters/);
+  });
+});
+
+describe('get_post', () => {
+  test('returns the post as plain text with its markup stripped', async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      name: 'get_post',
+      arguments: { searchtitle: 'farming-kelp' },
+    });
+    const text = textOf(result);
+    assert.match(text, /# Farming Kelp/);
+    assert.match(text, /Kelp grows fast in Coral Bay\./);
+    assert.doesNotMatch(text, /<p>/, 'html should be stripped');
+    assert.doesNotMatch(text, /meta-data/, 'meta-data comment should be stripped');
+  });
+
+  test('flags an unknown slug as an error and suggests how to recover', async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      name: 'get_post',
+      arguments: { searchtitle: 'no-such-post' },
+    });
+    assert.equal(result.isError, true);
+    assert.match(textOf(result), /No post with slug "no-such-post"/);
+    assert.match(textOf(result), /search_posts or list_posts/);
+  });
+});
+
+describe('list_categories', () => {
+  test('counts posts per category, most common first', async () => {
+    const client = await connect();
+    const result = await client.callTool({ name: 'list_categories', arguments: {} });
+    const text = textOf(result);
+    assert.match(text, /2 posts across 2 categories/);
+    assert.match(text, /- tech: 1 post\(s\)/);
+    assert.match(text, /- thoughts: 1 post\(s\)/);
+  });
+});
+
+describe('post resource', () => {
+  test('lists every post as a resource', async () => {
+    const client = await connect();
+    const { resources } = await client.listResources();
+    assert.deepEqual(resources.map((resource) => resource.uri).sort(), [
+      'blog://posts/anemone-notes',
+      'blog://posts/farming-kelp',
+    ]);
+  });
+
+  test('reads a single post by uri', async () => {
+    const client = await connect();
+    const result = await client.readResource({ uri: 'blog://posts/farming-kelp' });
+    const [content] = result.contents;
+    assert.ok(content);
+    assert.equal(content.mimeType, 'text/plain');
+    // Resource contents are text-or-blob; the blog only serves text.
+    assert.ok('text' in content, 'expected a text resource, not a blob');
+    assert.match(String(content.text), /# Farming Kelp/);
+  });
+});
+
+describe('formatting', () => {
+  test('formatPost leads with the title and links back to the public url', () => {
+    const text = formatPost(kelpPost);
+    assert.match(text, /^# Farming Kelp\n/);
+    assert.match(text, /https:\/\/blog\.mikemjharris\.com\/posts\/farming-kelp/);
+  });
+
+  test('formatSummary omits the tag list when a post has no tags', () => {
+    assert.doesNotMatch(formatSummary(summarise(anemonePost)), / · $/m);
+    assert.match(formatSummary(summarise(kelpPost)), /kelp, seaweed/);
+  });
+});


### PR DESCRIPTION
`blog-mcp-server.ts` was **170 lines with no tests**. Smoke only ever POSTed `tools/list`, so `tools/call` was never exercised by anything.

I called all four tools by hand first — they work correctly, including `get_post`'s unknown-slug branch. So this was a gap, not a bug. But nothing would have caught a regression in a shipped feature.

## Approach

Drives the server through a **real MCP client over the SDK's `InMemoryTransport`**, so the tools are called the way an agent calls them rather than by reaching into internals. No HTTP, no mocking.

Covers: tool registration and read-only annotations, search ranking and limits, list filters and `since`, the empty-result messages (which should be text, not errors), the unknown-slug error and its recovery hint, the resource template list and read, and schema rejection of an out-of-range `limit`.

| file | line % | branch % |
| --- | --- | --- |
| `blog-mcp-server.ts` | 0 → **100** | 0 → **81** |

Tests go 22 → 38.

Smoke also now **calls** a tool rather than only listing them, so the full path — parse the posts, search them, format the reply — is exercised over HTTP too. 18 → 19 checks.

## Also: a real flake, fixed

Smoke hardcoded port 8123. **That blocked a push earlier today** — the pre-push hook failed, and the same command passed on retry. A fixed port fails whenever anything else is listening, including a previous run that hasn't fully released the socket.

It now asks the OS for a spare port. Verified by running two smoke suites concurrently — both pass 19/19, which the old version could not have done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)