### PR TITLE
feat: 404 unmatched URLs instead of redirecting to the homepage

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -45,7 +45,12 @@ self.addEventListener('fetch', function (event) {
     caches.open(cacheName).then(function (cache) {
       return caches.match(event.request).then(function (response) {
         var fetchPromise = fetch(event.request).then(function (networkResponse) {
-          cache.put(event.request, networkResponse.clone());
+          // Only cache successes. Unmatched URLs now 404 rather than redirecting to
+          // the homepage, and caching those would keep serving the 404 after the
+          // page starts existing.
+          if (networkResponse.ok) {
+            cache.put(event.request, networkResponse.clone());
+          }
           return networkResponse;
         });
         return response || fetchPromise;

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -78,8 +78,8 @@ const expectStatus = (res: Response, status: number): void => {
   if (res.status !== status) throw new Error(`expected ${status}, got ${res.status}`);
 };
 
-// Never follow redirects: the catch-all route sends anything unmatched to the homepage,
-// so a followed redirect turns a missing route or asset into a passing 200.
+// Never follow redirects: a followed redirect would turn a route that has quietly
+// started redirecting into a passing 200.
 const get = (url: string, options?: RequestInit): Promise<Response> =>
   fetch(url, { redirect: 'manual', ...options });
 
@@ -163,6 +163,19 @@ const run = async (): Promise<void> => {
   await check('node_modules is not served', async () => {
     const res = await get(`${base}/express/package.json`);
     if (res.status === 200) throw new Error('node_modules is exposed over HTTP');
+  });
+
+  await check('an unknown path 404s with a real page', async () => {
+    const res = await get(`${base}/no-such-page`);
+    expectStatus(res, 404);
+    const html = await res.text();
+    if (!html.includes('Page not found')) throw new Error('404 did not render the error page');
+    if (!html.includes('<article')) throw new Error('404 is not wrapped in the site layout');
+  });
+
+  await check('an unknown post slug 404s rather than soft-404ing', async () => {
+    const res = await get(`${base}/posts/no-such-post`);
+    expectStatus(res, 404);
   });
 };
 

--- a/server/routes/main.ts
+++ b/server/routes/main.ts
@@ -3,11 +3,6 @@ import { Builder } from 'xml2js';
 import { mountMcp } from '../mcp/route.ts';
 import type { Post } from '../helpers/source-content.ts';
 
-const notFound = {
-  title: '404',
-  intro: "the page you were looking for wasn't found",
-};
-
 const date = new Date();
 
 export default (app: Express, posts: Post[]): void => {
@@ -37,12 +32,16 @@ export default (app: Express, posts: Post[]): void => {
     res.render('templates/talks', { posts: posts });
   });
 
-  app.get('/posts/:id', (req, res) => {
-    const postId = req.params.id;
-    const postToShow: Post | typeof notFound =
-      posts.find((post) => post.searchtitle === postId) ?? notFound;
+  app.get('/posts/:id', (req, res, next) => {
+    const post = posts.find((candidate) => candidate.searchtitle === req.params.id);
+    // Fall through to the 404 handler rather than rendering a page that says "not
+    // found" while returning 200 — a soft 404 tells crawlers the page is fine.
+    if (!post) {
+      next();
+      return;
+    }
 
-    res.render('templates/post', { post: postToShow });
+    res.render('templates/post', { post });
   });
 
   app.get('/contact', (_req, res) => {

--- a/server/server.ts
+++ b/server/server.ts
@@ -38,17 +38,23 @@ app.use(express.static(path.join(import.meta.dirname, '../public')));
 
 registerRoutes(app, posts);
 
-app.get('/{*splat}', (_req, res) => {
-  res.redirect('../');
+// Anything unmatched is a 404. This used to redirect to the homepage, which made
+// every broken link on the site look like it worked — five real ones were hiding
+// behind it.
+app.use((_req, res) => {
+  res.status(404).render('templates/error', {
+    title: 'Page not found',
+    intro: "The page you were looking for isn't here.",
+  });
 });
 
 const errorHandler: ErrorRequestHandler = (err, _req, res, _next) => {
   console.error(err);
   const status = err instanceof Error && 'status' in err ? Number(err.status) : 500;
-  res
-    .status(Number.isInteger(status) ? status : 500)
-    .type('text')
-    .send('Something went wrong');
+  res.status(Number.isInteger(status) ? status : 500).render('templates/error', {
+    title: 'Something went wrong',
+    intro: 'That is my fault, not yours.',
+  });
 };
 
 app.use(errorHandler);

--- a/server/views/templates/error.hbs
+++ b/server/views/templates/error.hbs
@@ -1,0 +1,9 @@
+<h2>{{title}}</h2>
+<div class="content">
+  <p>{{intro}}</p>
+  <p>
+    Try the <a href="/posts">list of posts</a>, or head back to the
+    <a href="/">homepage</a>. If you followed a link here from somewhere on this site,
+    <a href="/contact">let me know</a> and I'll fix it.
+  </p>
+</div>


### PR DESCRIPTION
Stacked on [#39](https://github.com/mikemjharris/blog/pull/39) — both touch `scripts/smoke.ts`. Base retargets to `master` when #39 merges.

## What changed

| request | before | after |
| --- | --- | --- |
| `/nonexistent` | 302 → `/` | **404** + error page |
| `/posts/no-such-post` | **200** + page titled "404" | **404** + error page |
| `/images/missing.png` | 302 → `/` | **404** |
| `/rss.xm` | 302 → `/` | **404** |

The redirect is exactly why five broken links went unnoticed for years — every one of them *looked* like it worked. It also made the 404 middleware unreachable dead code, which is why it got deleted back in #29.

The unknown-slug case was worse than the catch-all: it rendered the post template with a "404" title and returned **200**. A soft 404 tells crawlers the page is fine and should stay indexed.

## The error page

There was no error template *at all* — the error handler referenced `templates/error`, which doesn't exist, so it would have thrown if it had ever run. (It never did; see #33, where it also had the wrong arity.) Now there's a real one, rendered inside the site layout with links back to the posts list, the homepage and contact.

The same template serves 500s.

## Service worker

Worth flagging because this change is what makes it matter: the service worker did `cache.put(...)` on **every** response. That was mostly harmless when bad URLs redirected — it cached the homepage. With real 404s it would pin a 404 in the cache for a slug that later starts existing. It now only caches successes.

## Verification

Smoke gains two checks (19 → 21): an unknown path must 404 *and* render the error page inside the layout, and an unknown slug must 404 rather than soft-404. Confirmed against the running server that all four bad-URL shapes 404 and that `/`, `/posts`, `/about`, a real post, `/rss.xml` and `/api/posts` all still 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)