### PR TITLE
fix: make npm run dev work again

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,11 @@
     "typescript": "^7.0.2"
   },
   "nodemonConfig": {
-    "delay": 2500
+    "delay": 2500,
+    "execMap": {
+      "ts": "node",
+      "cts": "node",
+      "mts": "node"
+    }
   }
 }


### PR DESCRIPTION
`npm run dev` has been broken on master since the TypeScript migration:

```
[nodemon] starting `ts-node ./server/server.ts`
sh: ts-node: command not found
[nodemon] failed to start process, "ts-node" exec not found
```

nodemon maps a `.ts` entry point to `ts-node` by default. We don't install ts-node — Node 24 strips the types itself — so the dev server never starts.

**My miss, in [#33](https://github.com/mikemjharris/blog/pull/33).** That PR verified `npm start`, the tests, the build, the smoke test and the Docker image, but never ran `npm run dev`. Everything CI touches kept working, which is exactly why it went unnoticed — CI doesn't run the dev script and neither did I.

It surfaced while setting up the compose dev container, where it failed identically. Worth stressing it was never a Docker problem.

## Fix

`execMap` points `.ts`, `.cts` and `.mts` at plain `node`.

## Verified

- server boots and serves 200
- nodemon restarts on a `.ts` change
- the asset watcher rebuilds on a `.scss` change

Not something CI can catch without starting a watcher and waiting on it, which isn't worth the flakiness. The compose PR that follows exercises the same path, which is the practical guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)