### PR TITLE
feat: add a compose dev service

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,23 @@ or for prod
 compiles the Sass, concatenates and minifies the client JS, precompiles the Handlebars
 templates and copies the browser libraries into `public/dist`.
 
+Or in a container, needing no node on the host at all:
+
+```
+    docker compose up dev
+```
+
+Same address, same watching — edit a file and nodemon restarts or the assets rebuild.
+One-off commands go through `docker compose run --rm dev npm test`.
+
+Dependencies live in a named volume rather than the host's `node_modules`, which cannot
+be shared: esbuild ships a platform-specific binary, so a macOS install will not run on
+linux. The volume fills itself on first run and refills whenever `package-lock.json`
+moves. The git hooks mount the same one, so it is installed once for both.
+
+If editing stops triggering a restart, the bind mount is not forwarding file events —
+uncomment `CHOKIDAR_USEPOLLING` in `compose.yaml`.
+
 TypeScript
 ==========
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,39 @@
+# Development in a container, so nothing local depends on the host's node version.
+#
+#   docker compose up dev                   — http://localhost:8000, watching for changes
+#   docker compose run --rm dev npm test    — a one-off command
+#
+# node_modules is the same named volume the git hooks use, so dependencies are
+# installed once and shared. It cannot be the host's: esbuild ships a
+# platform-specific binary and a macOS install will not run on linux.
+
+services:
+  dev:
+    image: node:24-slim
+    working_dir: /app
+    ports:
+      - '8000:8000'
+    volumes:
+      - .:/app
+      - node_modules:/app/node_modules
+    # If edits stop triggering a restart or a rebuild, the bind mount is not
+    # forwarding file events — uncomment to make both watchers poll instead. Left
+    # off by default because Docker Desktop forwards them fine and polling costs CPU.
+    # environment:
+    #   CHOKIDAR_USEPOLLING: 'true'
+    command: >
+      sh -c '
+        if ! cmp -s package-lock.json node_modules/.lock-stamp; then
+          echo "installing dependencies..."
+          npm ci --no-audit --no-fund
+          cp package-lock.json node_modules/.lock-stamp
+        fi
+        exec npm run dev
+      '
+
+volumes:
+  # Named explicitly rather than left to compose's project prefix, so this is the
+  # same volume scripts/hook-run.sh mounts. Not external: compose should create it
+  # on first run rather than erroring because it does not exist yet.
+  node_modules:
+    name: blog-node-modules


### PR DESCRIPTION
Stacked on [#43](https://github.com/mikemjharris/blog/pull/43) (containerised hooks), which is stacked on [#44](https://github.com/mikemjharris/blog/pull/44) (the `npm run dev` fix). Bases retarget as each merges.

Completes the picture from #43 — with this, development doesn't need node on the host at all.

```
docker compose up dev                  # http://localhost:8000, watching
docker compose run --rm dev npm test   # one-off
```

## Watching works, without polling

The thing I expected to be the problem. Verified with before-and-after log counts rather than by eye:

| edited on the host | result in the container |
| --- | --- |
| `server/routes/main.ts` | nodemon restarts |
| `public/stylesheets/mobile.scss` | assets rebuild |

I'd initially set `CHOKIDAR_USEPOLLING`, then tested without it — Docker Desktop forwards the file events fine, and polling costs CPU for nothing. It's left commented in `compose.yaml` for mounts that don't forward events.

## The volume

Dependencies live in the same named volume `scripts/hook-run.sh` mounts, so they're installed once for both. Two details found by testing:

- It **can't** be the host's `node_modules` — esbuild ships a platform-specific binary, so a macOS install fails on linux.
- It's **not** `external: true`. I had it that way first, and a genuine cold start failed with `external volume "blog-node-modules" not found`. Naming it without `external` means compose creates it on first run.

Verified from a true cold start — no volume, no container — through to a 200 on the homepage, then confirmed the hooks reuse the same volume without reinstalling.

## Note

This surfaced the `npm run dev` breakage in #44 — the compose service failed with the same `ts-node: not found` the host did. Merge that one first or this won't start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)