### PR TITLE
fix: repair the RSS feed and make it testable

### DIFF
--- a/server/content/posts/tlcc-talk-2019.html
+++ b/server/content/posts/tlcc-talk-2019.html
@@ -5,7 +5,7 @@
 <!-- meta-data author: Mike Harris  -->
 <!-- meta-data category: thoughts -->
 <!-- meta-data tags: talk -->
-<!-- meta-data twitterimage: https://blog.mikemjharris.com//images/tlcc-panel.png  -->
+<!-- meta-data twitterimage: https://blog.mikemjharris.com/images/tlcc-panel.png  -->
 <!-- meta-data twittercard: summary_large_image -->
 
 <p>

--- a/server/routes/main.ts
+++ b/server/routes/main.ts
@@ -1,9 +1,7 @@
 import type { Express } from 'express';
-import { Builder } from 'xml2js';
 import { mountMcp } from '../mcp/route.ts';
+import { buildFeed } from '../rss.ts';
 import type { Post } from '../helpers/source-content.ts';
-
-const date = new Date();
 
 export default (app: Express, posts: Post[]): void => {
   mountMcp(app, posts);
@@ -58,41 +56,6 @@ export default (app: Express, posts: Post[]): void => {
   });
 
   app.get('/rss.xml', (_req, res) => {
-    const rss = {
-      rss: {
-        $: {
-          'xmlns:atom': 'http://www.w3.org/2005/Atom',
-          version: '2.0',
-        },
-        channel: {
-          title: "MikeMJHarris' Blog",
-          link: 'https://blog.mikemjharris.com/',
-          description: 'Tech, some creative bits and other thoughts',
-          generator: "MikeMJHarris' custom generator",
-          language: 'en-us',
-          lastBuildDate: date.toUTCString(),
-          'atom:link': {
-            $: {
-              href: 'https://blog.mikemjharris.com/rss.xml',
-              rel: 'self',
-              type: 'application/rss+xml',
-            },
-          },
-          item: posts.map((post) => ({
-            title: post.title,
-            link: 'https://blog.mikemjharris.com/posts/' + post.searchtitle,
-            pubDate: post.date,
-            guid: post.searchtitle,
-            description: post.body.replace(/href="\//g, 'href="https://blog.mikemjharris.com/'),
-          })),
-        },
-      },
-    };
-
-    const builder = new Builder();
-    const xml = builder.buildObject(rss);
-
-    res.set('Content-Type', 'text/xml');
-    res.send(xml);
+    res.type('application/rss+xml').send(buildFeed(posts, new Date()));
   });
 };

--- a/server/rss.ts
+++ b/server/rss.ts
@@ -1,0 +1,85 @@
+import { Builder } from 'xml2js';
+import { BASE_URL } from './helpers/post-search.ts';
+import type { Post } from './helpers/source-content.ts';
+
+const FEED_URL = `${BASE_URL}/rss.xml`;
+
+/**
+ * Post bodies are written with site-root-relative links, which resolve against the
+ * reader's own domain once the body is embedded in a feed. The negative lookahead
+ * keeps protocol-relative URLs (`src="//codepen.io/..."`) intact — without it they
+ * become `https://blog.mikemjharris.com//codepen.io/...`.
+ */
+export const absolutiseUrls = (html: string): string =>
+  html.replace(/(href|src)="\/(?!\/)/g, `$1="${BASE_URL}/`);
+
+/**
+ * RSS 2.0 wants RFC-822 dates. Posts carry a display date like `21 Jul 2019`, which
+ * readers are left to guess at. Returns undefined for a date that will not parse, so
+ * the element is omitted rather than emitted as something unparseable.
+ */
+export const toRfc822 = (date: string | undefined): string | undefined => {
+  if (!date) return undefined;
+  const parsed = new Date(date);
+  if (Number.isNaN(parsed.getTime())) return undefined;
+
+  // A post date is a calendar day, not an instant. Parsing gives local midnight, so
+  // converting that straight to UTC moves the post back a day in any timezone ahead
+  // of UTC — a post dated 4 May shows as 3 May to subscribers when the server runs
+  // in BST. Rebuild it as UTC midnight so the day is the authored one everywhere.
+  return new Date(
+    Date.UTC(parsed.getFullYear(), parsed.getMonth(), parsed.getDate()),
+  ).toUTCString();
+};
+
+interface FeedItem {
+  title: string | undefined;
+  link: string;
+  guid: { _: string; $: { isPermaLink: 'false' } };
+  description: string;
+  pubDate?: string;
+}
+
+const toItem = (post: Post): FeedItem => {
+  const item: FeedItem = {
+    title: post.title,
+    link: `${BASE_URL}/posts/${post.searchtitle}`,
+    // The slug is not a URL, and guid defaults to isPermaLink="true". The value is
+    // deliberately unchanged: it is the identity readers dedupe on, so changing it
+    // would resurface all 76 posts as new.
+    guid: { _: post.searchtitle, $: { isPermaLink: 'false' } },
+    description: absolutiseUrls(post.body),
+  };
+
+  const pubDate = toRfc822(post.date);
+  if (pubDate) item.pubDate = pubDate;
+
+  return item;
+};
+
+/** `now` is passed in rather than read here so the feed is testable and never stale. */
+export const buildFeed = (posts: Post[], now: Date): string =>
+  new Builder().buildObject({
+    rss: {
+      $: {
+        'xmlns:atom': 'http://www.w3.org/2005/Atom',
+        version: '2.0',
+      },
+      channel: {
+        title: "MikeMJHarris' Blog",
+        link: `${BASE_URL}/`,
+        description: 'Tech, some creative bits and other thoughts',
+        generator: "MikeMJHarris' custom generator",
+        language: 'en-us',
+        lastBuildDate: now.toUTCString(),
+        'atom:link': {
+          $: {
+            href: FEED_URL,
+            rel: 'self',
+            type: 'application/rss+xml',
+          },
+        },
+        item: posts.map(toItem),
+      },
+    },
+  });

--- a/server/tests/rss.test.ts
+++ b/server/tests/rss.test.ts
@@ -1,0 +1,132 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildFeed, absolutiseUrls, toRfc822 } from '../rss.ts';
+import { getPosts } from '../helpers/source-content.ts';
+import type { Post } from '../helpers/source-content.ts';
+
+const BASE = 'https://blog.mikemjharris.com';
+
+const post = (overrides: Partial<Post> = {}): Post => ({
+  template: 'farming-kelp.html',
+  title: 'Farming Kelp',
+  searchtitle: 'farming-kelp',
+  date: '4 May 2021',
+  category: 'tech',
+  intro: 'Growing kelp at Coral Bay',
+  tags: [],
+  body: '<p>Kelp.</p>',
+  ...overrides,
+});
+
+const NOW = new Date('2026-05-16T10:00:00Z');
+
+describe('absolutiseUrls', () => {
+  test('rewrites root-relative image sources', () => {
+    assert.equal(
+      absolutiseUrls('<img src="/images/kelp.jpg" />'),
+      `<img src="${BASE}/images/kelp.jpg" />`,
+    );
+  });
+
+  test('rewrites root-relative links', () => {
+    assert.equal(
+      absolutiseUrls('<a href="/posts/anemone">anemone</a>'),
+      `<a href="${BASE}/posts/anemone">anemone</a>`,
+    );
+  });
+
+  test('leaves protocol-relative urls alone', () => {
+    // Without a lookahead these become https://blog.mikemjharris.com//codepen.io/...
+    const html = '<script src="//codepen.io/embed/ei.js"></script>';
+    assert.equal(absolutiseUrls(html), html);
+  });
+
+  test('leaves absolute urls alone', () => {
+    const html = '<a href="https://example.com/reef">reef</a>';
+    assert.equal(absolutiseUrls(html), html);
+  });
+
+  test('leaves anchors and relative paths alone', () => {
+    const html = '<a href="#summary">jump</a><a href="other.html">other</a>';
+    assert.equal(absolutiseUrls(html), html);
+  });
+});
+
+describe('toRfc822', () => {
+  test('converts a display date to the format the spec requires', () => {
+    assert.equal(toRfc822('4 May 2021'), 'Tue, 04 May 2021 00:00:00 GMT');
+  });
+
+  test('returns undefined for a date that will not parse', () => {
+    assert.equal(toRfc822('not a date'), undefined);
+    assert.equal(toRfc822(undefined), undefined);
+  });
+});
+
+describe('buildFeed', () => {
+  const feed = (posts: Post[]): string => buildFeed(posts, NOW);
+
+  test('emits pubDate in RFC-822, not the display format', () => {
+    const xml = feed([post()]);
+    assert.match(xml, /<pubDate>Tue, 04 May 2021 00:00:00 GMT<\/pubDate>/);
+    assert.doesNotMatch(xml, /<pubDate>4 May 2021<\/pubDate>/);
+  });
+
+  test('omits pubDate rather than emitting something unparseable', () => {
+    const xml = feed([post({ date: 'sometime last spring' })]);
+    assert.doesNotMatch(xml, /<pubDate>/);
+    // The item itself still makes it into the feed.
+    assert.match(xml, /<title>Farming Kelp<\/title>/);
+  });
+
+  test('marks the guid as not a permalink, keeping the value stable', () => {
+    const xml = feed([post()]);
+    assert.match(xml, /<guid isPermaLink="false">farming-kelp<\/guid>/);
+  });
+
+  test('absolutises image sources inside the description', () => {
+    const xml = feed([post({ body: '<img src="/images/kelp.jpg" />' })]);
+    assert.match(xml, /src="https:\/\/blog\.mikemjharris\.com\/images\/kelp\.jpg"/);
+  });
+
+  test('lastBuildDate reflects the moment asked for, not process start', () => {
+    assert.match(feed([post()]), /<lastBuildDate>Sat, 16 May 2026 10:00:00 GMT<\/lastBuildDate>/);
+    const later = buildFeed([post()], new Date('2026-06-01T00:00:00Z'));
+    assert.match(later, /<lastBuildDate>Mon, 01 Jun 2026 00:00:00 GMT<\/lastBuildDate>/);
+  });
+
+  test('links to the canonical post url', () => {
+    assert.match(
+      feed([post()]),
+      /<link>https:\/\/blog\.mikemjharris\.com\/posts\/farming-kelp<\/link>/,
+    );
+  });
+
+  test('declares itself as the feed via atom:link', () => {
+    assert.match(feed([post()]), /rel="self"/);
+    assert.match(feed([post()]), /href="https:\/\/blog\.mikemjharris\.com\/rss\.xml"/);
+  });
+});
+
+describe('the real feed', () => {
+  const xml = buildFeed(getPosts(), NOW);
+
+  test('every item carries a pubDate', () => {
+    const items = (xml.match(/<item>/g) ?? []).length;
+    const dates = (xml.match(/<pubDate>/g) ?? []).length;
+    assert.ok(items > 20, `expected a real feed, got ${items} items`);
+    assert.equal(dates, items, 'every post should have a parseable date');
+  });
+
+  test('no root-relative urls survive into the feed', () => {
+    // This is the bug that broke every image for subscribers.
+    assert.doesNotMatch(xml, /(href|src)="\/(?!\/)/);
+  });
+
+  test('protocol-relative embeds survive the rewrite', () => {
+    // The codepen embeds are written `src="//codepen.io/..."`. A rewrite without a
+    // lookahead turns them into https://blog.mikemjharris.com//codepen.io/...
+    assert.match(xml, /src="\/\/codepen\.io/);
+    assert.doesNotMatch(xml, /blog\.mikemjharris\.com\/\/codepen/);
+  });
+});


### PR DESCRIPTION
Four bugs, all in the part of `routes/main.ts` no test reached — that file was at 45% line coverage and this was the uncovered half.

## 1. Every image was broken for subscribers

Post bodies are written with root-relative URLs. Only `href` was rewritten to absolute, so **100 `img src` attributes** resolved against the *reader's* domain rather than the blog.

The rewrite now covers `src` too — with a negative lookahead, because six codepen embeds are written `src="//codepen.io/..."` and a naive `="\/` would turn those into `blog.mikemjharris.com//codepen.io/...`.

## 2. `pubDate` wasn't RFC-822

It emitted the display date, `16 May 2026`. RSS 2.0 wants `Sat, 16 May 2026 00:00:00 GMT`. Readers that can't parse it fall back to fetch time, which reorders the feed.

Dates are also rebuilt as **UTC midnight**. Parsing `4 May 2021` gives *local* midnight, so `toUTCString()` on a server running in BST emitted `Mon, 03 May 2021 23:00:00 GMT` — publishing every post a day early. I hit this writing the test and fixed the implementation rather than the assertion.

## 3. `guid` had no `isPermaLink`

It carried the bare slug, and `guid` defaults to `isPermaLink="true"`, so readers treated `three-key-keyboard` as a URL.

**The value is deliberately unchanged.** It's the identity readers dedupe on — switching it to the post URL would have resurfaced all 76 posts as unread for every subscriber. Adding the attribute is safe; changing the string is not.

## 4. `lastBuildDate` was frozen at boot

`const date = new Date()` at module load, so it reported process start forever.

## Structure

Generation moves to `server/rss.ts`, taking `now` as an argument so the document is testable without a clock. `routes/main.ts` drops from 98 lines to 66 and the route is now three lines.

Writing the tests also turned up a post whose `twitterimage` URL had a double slash (`.com//images/...`) — fixed. It resolves today because Express normalises it, but Twitter's crawler isn't obliged to.

## Verified by mutation

| reintroduce the bug | tests that fail |
| --- | --- |
| stop rewriting `src` | 4 |
| `pubDate` back to display format | 2 |
| `guid` loses `isPermaLink` | 1 |
| `lastBuildDate` frozen | 1 |

72 tests, all green restored. Live feed confirmed: 76 items, 76 pubDates, zero root-relative URLs, codepen embeds intact, and the content type is now `application/rss+xml` rather than `text/xml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)