### PR TITLE
feat: add security response headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "cookie-parser": "^1.4.7",
         "express": "^5.2.1",
         "express-handlebars": "^9.0.1",
+        "helmet": "^8.3.0",
         "morgan": "^1.11.0",
         "xml2js": "^0.6.2",
         "zod": "^4.4.3"
@@ -2485,6 +2486,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.3.0.tgz",
+      "integrity": "sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
       }
     },
     "node_modules/hono": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "cookie-parser": "^1.4.7",
     "express": "^5.2.1",
     "express-handlebars": "^9.0.1",
+    "helmet": "^8.3.0",
     "morgan": "^1.11.0",
     "xml2js": "^0.6.2",
     "zod": "^4.4.3"

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -177,6 +177,29 @@ const run = async (): Promise<void> => {
     const res = await get(`${base}/posts/no-such-post`);
     expectStatus(res, 404);
   });
+
+  await check('security headers are set', async () => {
+    const res = await get(`${base}/`);
+    const required = [
+      'x-content-type-options',
+      'referrer-policy',
+      'strict-transport-security',
+      'x-frame-options',
+      'content-security-policy-report-only',
+    ];
+    const missing = required.filter((header) => !res.headers.get(header));
+    if (missing.length) throw new Error(`missing: ${missing.join(', ')}`);
+    if (res.headers.get('x-powered-by')) throw new Error('x-powered-by is still advertised');
+  });
+
+  await check('the csp still covers the libraries the layout loads', async () => {
+    const csp = (await get(`${base}/`)).headers.get('content-security-policy-report-only') ?? '';
+    // Loosely pinned: enough that dropping an origin the pages depend on is caught,
+    // without re-encoding the whole policy here.
+    for (const origin of ['cdnjs.cloudflare.com', 'platform.twitter.com', 'codepen.io']) {
+      if (!csp.includes(origin)) throw new Error(`csp no longer allows ${origin}`);
+    }
+  });
 };
 
 const main = async (): Promise<void> => {

--- a/server/security.ts
+++ b/server/security.ts
@@ -1,0 +1,60 @@
+import helmet from 'helmet';
+import type { RequestHandler } from 'express';
+
+/**
+ * Origins the site actually loads subresources from, as opposed to merely links to.
+ * Gathered by grepping the layout, the templates and every post for script, img,
+ * iframe and link tags — not guessed.
+ */
+const CDNJS = 'https://cdnjs.cloudflare.com'; // Prism, css and js
+const GOOGLE_FONTS = 'https://fonts.googleapis.com';
+const GOOGLE_FONTS_FILES = 'https://fonts.gstatic.com';
+const ANALYTICS = 'https://www.google-analytics.com';
+const TWITTER = 'https://platform.twitter.com';
+const CODEPEN = 'https://codepen.io';
+const CODEPEN_ASSETS = 'https://*.codepen.io'; // assets. and static.
+const YOUTUBE = 'https://www.youtube.com';
+const INSTAGRAM = 'https://www.instagram.com';
+
+/**
+ * Content-Security-Policy runs in report-only to begin with. Enforcing it today
+ * would need 'unsafe-inline' for scripts anyway — the analytics snippet and the
+ * chart post are both inline — so it would buy little while risking a broken page.
+ * Watch the reports, move the inline scripts to nonces, then switch to enforcing.
+ */
+const contentSecurityPolicy = {
+  useDefaults: false,
+  reportOnly: true,
+  directives: {
+    'default-src': ["'self'"],
+    'base-uri': ["'self'"],
+    'object-src': ["'none'"],
+    'frame-ancestors': ["'none'"],
+    'form-action': ["'self'"],
+    'script-src': ["'self'", "'unsafe-inline'", CDNJS, ANALYTICS, TWITTER, CODEPEN_ASSETS],
+    'style-src': ["'self'", "'unsafe-inline'", CDNJS, GOOGLE_FONTS],
+    'font-src': ["'self'", 'data:', GOOGLE_FONTS_FILES],
+    // Posts embed images from a long tail of hosts; https: keeps it honest without
+    // enumerating every one.
+    'img-src': ["'self'", 'data:', 'https:'],
+    'connect-src': ["'self'", ANALYTICS],
+    'frame-src': [CODEPEN, CODEPEN_ASSETS, YOUTUBE, TWITTER, INSTAGRAM],
+  },
+};
+
+export const securityHeaders = (): RequestHandler =>
+  helmet({
+    contentSecurityPolicy,
+    // The blog links out constantly; a bare origin referrer is the useful middle.
+    referrerPolicy: { policy: 'strict-origin-when-cross-origin' },
+    // Matches frame-ancestors 'none' above. helmet defaults to SAMEORIGIN, which
+    // would quietly be the weaker of the two while the CSP is still report-only.
+    xFrameOptions: { action: 'deny' },
+    // Six months, and no preload: preload is a one-way door for the whole domain.
+    strictTransportSecurity: { maxAge: 15552000, includeSubDomains: true },
+    // Served over http in dev and behind TLS termination in production, so leave
+    // upgrade-insecure-requests off rather than break local development.
+    crossOriginEmbedderPolicy: false,
+    // Third-party embeds (codepen, youtube, twitter) need to load cross-origin.
+    crossOriginResourcePolicy: { policy: 'cross-origin' },
+  });

--- a/server/server.ts
+++ b/server/server.ts
@@ -7,9 +7,14 @@ import compression from 'compression';
 import { engine } from 'express-handlebars';
 import { getPosts } from './helpers/source-content.ts';
 import registerRoutes from './routes/main.ts';
+import { securityHeaders } from './security.ts';
 import blogHelpers from '../public/javascripts/helpers.cjs';
 
 const app = express();
+
+// Nothing to gain from advertising the framework.
+app.disable('x-powered-by');
+app.use(securityHeaders());
 app.use(compression());
 
 const posts = getPosts();


### PR DESCRIPTION
The site sent **no security headers at all** — no CSP, `X-Content-Type-Options`, `Referrer-Policy`, HSTS or frame options — and advertised `X-Powered-By: Express`.

helmet supplies them. It has **zero dependencies** of its own and ships its own types, so it costs one package. `x-powered-by` is disabled outright.

## CSP is report-only, deliberately

Enforcing it today would still need `'unsafe-inline'` for scripts — the analytics snippet in the layout and the chart post are both inline — so it would buy very little while risking a broken page. The route to enforcing is: watch the reports, move those two inline scripts to nonces, then flip it.

**The allowed origins were gathered, not guessed.** I grepped the layout, the templates and all 76 posts for `script`/`img`/`iframe`/`stylesheet` tags, which gave exactly six origins that are actually loaded (as opposed to merely linked to — the posts link to 40-odd hosts they never fetch from).

Then I checked the other direction: walked the rendered pages and confirmed every subresource is covered by the policy.

```
subresources NOT covered by the policy: 0
```

That check first reported 7 failures, all `https://blog.mikemjharris.com/rss.xml` — my checker was treating `<link rel="alternate">` as a stylesheet. CSP doesn't govern those.

## One thing worth calling out

helmet defaults `X-Frame-Options` to `SAMEORIGIN`, but the policy sets `frame-ancestors 'none'`. While the CSP is report-only, the weaker XFO is what actually applies — so the effective policy would have been looser than it reads. Set to `deny` so they agree.

## Verified

- MCP endpoint and its CORS headers still work behind helmet (checked a real `tools/call`)
- 23/23 smoke checks, up from 21 — two new ones assert the headers are present, `x-powered-by` is gone, and the CSP still names the origins the layout depends on
- 55 tests, typecheck and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)