### PR TITLE
chore: drop the discarded client-side post rendering

### DIFF
--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -1,7 +1,5 @@
 if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('/service-worker.js').then(function () {
-    console.log('Service Worker Registered');
-  });
+  navigator.serviceWorker.register('/service-worker.js');
 }
 
 (function ($) {
@@ -28,11 +26,10 @@ if ('serviceWorker' in navigator) {
 
         if (posts !== undefined) {
           if (id !== undefined) {
-            var post = findPost(id, posts);
-            console.log(post);
-            var html = MyApp.templates.post({ post: post });
-            $('article').html(html);
-            window.location.href = window.location.href;
+            // Individual posts are rendered server side — client-side handlebars was
+            // unreliable for them — so let the server do it rather than rendering a
+            // copy here and immediately throwing it away.
+            window.location.reload();
           } else {
             $('article').html('');
 
@@ -53,34 +50,9 @@ if ('serviceWorker' in navigator) {
 
     $('.menu').on('click', toggleMenu);
 
-    $('body').on('click', '.posts', function (e) {
-      if (!$(this).data('navigate')) {
-        e.preventDefault();
-        var _href = $(this).attr('href');
-        window.history.pushState(null, null, _href);
-        $('.active-menu').removeClass('active-menu');
-
-        _href = window.location.pathname;
-        var pathParams = _href.match(/(?:\/(\w+))(?:\/([\w/-]+))?/);
-        var id = pathParams[2];
-
-        var post = findPost(id, posts);
-
-        var html = MyApp.templates['post']({ post: post });
-        $('article').html('');
-        setTimeout(function () {
-          $('article').append(html);
-          // triggers code highlighting
-          try {
-            Prism.highlightAll();
-            console.log('aaa');
-            window.location.href = window.location.href;
-          } catch (e) {
-            console.error(e);
-          }
-        }, 0);
-      }
-    });
+    // Post links are deliberately not intercepted. They used to be rendered client
+    // side and then immediately reloaded, so the render was discarded every time —
+    // letting the browser navigate reaches the same page without the flash.
 
     $('.intro-animation ul li a').on('click', function (e) {
       if (!$(this).data('navigate')) {
@@ -117,16 +89,6 @@ if ('serviceWorker' in navigator) {
       }
     });
   });
-
-  function findPost(id, posts) {
-    var foundPost;
-    posts.forEach(function (post) {
-      if (post.searchtitle === id) {
-        foundPost = post;
-      }
-    });
-    return foundPost;
-  }
 
   function toggleMenu() {
     $('.menu').toggleClass('cross');


### PR DESCRIPTION
## What it was doing

Clicking a post link ran this:

```js
e.preventDefault();
window.history.pushState(null, null, _href);
var html = MyApp.templates['post']({ post: post });
setTimeout(function () {
  $('article').append(html);
  Prism.highlightAll();
  console.log('aaa');
  window.location.href = window.location.href;   // <- navigates
}, 0);
```

It rendered the post client-side, then set `location.href` to the URL it had just pushed — which navigates. **The render was discarded every time**, and the reader saw it flash before the server-rendered page replaced it. The `popstate` handler did the same.

That's consistent with the comment left in the other handler — *"sometimew get errors with handlebars... for now just rely on server side rendering"*. The reload was the workaround; the render in front of it was left behind.

## What changed

Post links aren't intercepted at all now — the browser navigates and reaches exactly the same page, without the wasted render or the flash. The `popstate` branch reloads outright instead of rendering a copy first.

**Menu navigation is untouched.** That one renders client-side and *keeps* the result — it's the case that actually worked, and it still does.

Also gone: two `console.log` calls that were shipping to production, one of them a bare `'aaa'`, and `findPost`, which nothing calls any more.

Bundle: **2677 → 1925 bytes**.

## Verified

Loaded the real rendered `/posts` page in jsdom with the built bundle and confirmed:

```
jQuery             : function
templates loaded   : 9
menu toggles       : true
post link navigates: true   (no longer intercepted)
runtime errors     : none
```

Worth a click-through in a real browser too — this is behaviour no automated check covers. A first attempt at driving it through jsdom with `resources: 'usable'` hung on the external cdnjs/Twitter/analytics fetches, which is a decent illustration of why this file has never had tests.

## Not done here

Migrating this file to TypeScript. It's globals-based against jQuery, Handlebars, Prism and `MyApp`, so it needs `@types/jquery` and some restructuring — worth its own PR rather than mixed into a behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)